### PR TITLE
Fix logo not loading in production (Propshaft digest path)

### DIFF
--- a/app/views/layouts/_logo_header.html.erb
+++ b/app/views/layouts/_logo_header.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid mt-2 mb-3">
   <div class="d-flex justify-content-end">
-    <%= image_tag "/assets/logo/medici_logo.jpeg", alt: "Medici Logo", class: "img-fluid rounded", style: "max-height: 75px;" %>
+    <%= image_tag "logo/medici_logo.jpeg", alt: "Medici Logo", class: "img-fluid rounded", style: "max-height: 75px;" %>
   </div>
 </div>

--- a/app/views/static_pages/medici_home.html.erb
+++ b/app/views/static_pages/medici_home.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div class="card-body p-4">
           <div class="text-center mb-4">
-            <%= image_tag "/assets/logo/medici_logo.jpeg", alt: "Medici Logo", class: "img-fluid rounded", style: "max-height: 200px;" %>
+            <%= image_tag "logo/medici_logo.jpeg", alt: "Medici Logo", class: "img-fluid rounded", style: "max-height: 200px;" %>
           </div>
           <h5 class="card-title mb-4">Te ayudamos a encontrar un estudio que pueda mejorar tu condición de salud</h5>
           

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,4 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap
 Rails.application.config.assets.paths << Rails.root.join("app/assets/images")
 Rails.application.config.assets.paths << Rails.root.join("app/assets/images/logo")
 Rails.application.config.assets.precompile << "bootstrap.bundle.min.js"
-Rails.application.config.assets.precompile += %w[ logo/medici_logo.png ]
+Rails.application.config.assets.precompile += %w[ logo/medici_logo.jpeg ]


### PR DESCRIPTION
## Problem
The Medici logo renders locally but is broken on Heroku.

## Root cause
The views referenced the logo by a hardcoded, non-digested path — `image_tag "/assets/logo/medici_logo.jpeg"`. That string bypasses Propshaft and is emitted as-is. It only worked locally because a leftover `public/assets/logo/medici_logo.jpeg` file existed (and `/public/assets` is gitignored, so it never reaches Heroku). In production, Propshaft's `assets:precompile` emits only **digest-stamped** files (e.g. `medici_logo-<digest>.jpeg`), so `/assets/logo/medici_logo.jpeg` 404s.

## Fix
- Reference the logo by its Propshaft **logical path** (`logo/medici_logo.jpeg`) in both views, so Rails emits the correct digested URL in every environment.
- Update the stale `config/initializers/assets.rb` precompile entry from `.png` → `.jpeg` (leftover from the earlier logo extension change; the `.png` source no longer exists).

## Verified
`image_path("logo/medici_logo.jpeg")` now resolves to `/assets/logo/medici_logo-<digest>.jpeg` after a clean precompile.