### PR TITLE
Add Capybara feature-spec suite + CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,51 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      PGHOST: localhost
+      PGPORT: 5432
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      # Chrome for the Capybara `js: true` feature specs. selenium-manager
+      # (bundled with selenium-webdriver) fetches a matching chromedriver.
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+
+      # Feature specs render the real layout, which links `application.css`.
+      # dartsass:build resolves @import "bootstrap" via the gem (no Node needed).
+      - name: Build CSS
+        run: bin/rails dartsass:build
+
+      - name: Prepare test database
+        run: bin/rails db:test:prepare
+
+      - name: Run RSpec (models, requests, policies, and browser feature specs)
+        run: bundle exec rspec
+

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,12 @@ group :development, :test do
   gem "shoulda-matchers", "~> 6.0"
 end
 
+group :test do
+  # Browser-driven feature specs (headless Chrome via Selenium).
+  gem "capybara", "~> 3.40"
+  gem "selenium-webdriver", "~> 4.27.0" # keep < 4.40 (4.40+ requires Ruby 3.4; this app is on 3.3.0)
+end
+
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     annotate (2.6.5)
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
@@ -95,6 +97,15 @@ GEM
     brakeman (8.0.5)
       racc
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -195,6 +206,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -252,6 +264,7 @@ GEM
     psych (5.2.6)
       date
       stringio
+    public_suffix (7.0.5)
     puma (6.6.0)
       nio4r (~> 2.0)
     pundit (2.5.0)
@@ -308,6 +321,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.4.4)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -354,6 +368,7 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    rubyzip (2.4.1)
     sass-embedded (1.89.0-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
     sass-embedded (1.89.0-aarch64-linux-musl)
@@ -371,6 +386,12 @@ GEM
     sass-embedded (1.89.0-x86_64-linux-musl)
       google-protobuf (~> 4.31)
     securerandom (0.4.1)
+    selenium-webdriver (4.27.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
     solid_cable (3.0.8)
@@ -423,11 +444,14 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (3.3.1)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.7.3)
 
 PLATFORMS
@@ -450,6 +474,7 @@ DEPENDENCIES
   bootstrap (~> 5.3.3)
   bootstrap-will_paginate
   brakeman
+  capybara (~> 3.40)
   cssbundling-rails
   dartsass-rails
   debug
@@ -468,6 +493,7 @@ DEPENDENCIES
   rails (~> 8.0.1)
   rspec-rails (~> 6.1.0)
   rubocop-rails-omakase
+  selenium-webdriver (~> 4.27.0)
   shoulda-matchers (~> 6.0)
   solid_cable
   solid_cache

--- a/spec/factories/criteria_profiles.rb
+++ b/spec/factories/criteria_profiles.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :criteria_profile do
     name { "Profile #{Faker::Lorem.word}" }
     description { Faker::Lorem.sentence }
-    association :user
+    association :user, factory: %i[user admin]
     association :study
   end
 end

--- a/spec/features/patient_state_spec.rb
+++ b/spec/features/patient_state_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature 'Patient state transitions', type: :feature, js: true do
+  let(:admin) { create(:user, :admin) }
+
+  before { login_as admin, scope: :user }
+
+  scenario 'an admin advances a prospect patient to candidate from the patients list' do
+    create(:patient) # starts in the prospect state
+
+    visit patients_path
+
+    # A prospect patient exposes the "Evaluar" (assess) transition to an admin.
+    expect(page).to have_button('Evaluar')
+
+    click_button 'Evaluar'
+
+    # After assess: prospect -> candidate. Assert on what the user sees (feature
+    # specs shouldn't reach into the DB across the server thread): the assess
+    # button is gone, the candidate-state actions appear, and the flash confirms.
+    expect(page).to have_content('Estado actualizado correctamente.')
+    expect(page).to have_no_button('Evaluar')
+    expect(page).to have_button('Aceptar')
+    expect(page).to have_button('Descartar')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'pundit/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -58,9 +58,6 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://rspec.info/features/6-0/rspec-rails
   config.infer_spec_type_from_file_location!
-
-  # Devise helpers for signing users in/out within request specs.
-  config.include Devise::Test::IntegrationHelpers, type: :request
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,26 @@
+require 'capybara/rails'
+require 'capybara/rspec'
+
+# Headless Chrome for JS-driven specs. selenium-manager (bundled with
+# selenium-webdriver 4.x) auto-downloads a matching chromedriver, so no
+# system chromedriver or webdrivers gem is needed.
+Capybara.register_driver :headless_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless=new')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+# Non-JS feature specs run under fast rack_test; `js: true` switches to Chrome.
+Capybara.default_driver    = :rack_test
+Capybara.javascript_driver = :headless_chrome
+
+# Quiet the Puma server that boots for `js: true` specs.
+Capybara.server = :puma, { Silent: true }
+
+# Turbo/Stimulus interactions can exceed the 2s default; give browser specs headroom.
+Capybara.default_max_wait_time = 5

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,14 @@
+RSpec.configure do |config|
+  # `sign_in` / `sign_out` for request specs.
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
+  # Capybara feature specs run through a separate Rack app, so they authenticate
+  # with Warden's `login_as user, scope: :user` rather than the integration
+  # `sign_in`. Pass an explicit scope to avoid Devise's mapping lookup (which
+  # inspects the user and can trip the User -> userable delegation on non-patient
+  # roles — see the delegated_type notes).
+  config.include Warden::Test::Helpers, type: :feature
+
+  config.before(:suite) { Warden.test_mode! }
+  config.after(:each, type: :feature) { Warden.test_reset! }
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  # Allow bare `create(...)` / `build(...)` in specs (existing specs may still
+  # use the fully-qualified `FactoryBot.create(...)` — both work).
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/views/trial_center_branches/edit.html.erb_spec.rb
+++ b/spec/views/trial_center_branches/edit.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "trial_center_branches/edit", type: :view do
       name: "MyString",
       initials: "MyString",
       description: "MyString",
-      trial_center_facility: nil
+      trial_center_facility: FactoryBot.create(:trial_center_facility)
     )
   }
 
@@ -23,8 +23,6 @@ RSpec.describe "trial_center_branches/edit", type: :view do
       assert_select "input[name=?]", "trial_center_branch[initials]"
 
       assert_select "input[name=?]", "trial_center_branch[description]"
-
-      assert_select "input[name=?]", "trial_center_branch[trial_center_facility_id]"
     end
   end
 end

--- a/spec/views/trial_center_branches/index.html.erb_spec.rb
+++ b/spec/views/trial_center_branches/index.html.erb_spec.rb
@@ -7,23 +7,21 @@ RSpec.describe "trial_center_branches/index", type: :view do
         name: "Name",
         initials: "Initials",
         description: "Description",
-        trial_center_facility: nil
+        trial_center_facility: FactoryBot.create(:trial_center_facility)
       ),
       TrialCenterBranch.create!(
         name: "Name",
         initials: "Initials",
         description: "Description",
-        trial_center_facility: nil
+        trial_center_facility: FactoryBot.create(:trial_center_facility)
       )
     ])
   end
 
   it "renders a list of trial_center_branches" do
     render
-    cell_selector = 'div>p'
-    assert_select cell_selector, text: Regexp.new("Name".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("Initials".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("Description".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new(nil.to_s), count: 2
+    assert_select ".branch-card", count: 2
+    assert_select "h5.card-header", text: "Name", count: 2
+    assert_select "h5.card-title", text: "Description", count: 2
   end
 end

--- a/spec/views/trial_center_branches/new.html.erb_spec.rb
+++ b/spec/views/trial_center_branches/new.html.erb_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe "trial_center_branches/new", type: :view do
       assert_select "input[name=?]", "trial_center_branch[initials]"
 
       assert_select "input[name=?]", "trial_center_branch[description]"
-
-      assert_select "input[name=?]", "trial_center_branch[trial_center_facility_id]"
     end
   end
 end

--- a/spec/views/trial_center_branches/show.html.erb_spec.rb
+++ b/spec/views/trial_center_branches/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "trial_center_branches/show", type: :view do
       name: "Name",
       initials: "Initials",
       description: "Description",
-      trial_center_facility: nil
+      trial_center_facility: FactoryBot.create(:trial_center_facility)
     ))
   end
 


### PR DESCRIPTION
Sets up browser-driven feature testing (Capybara + headless Chrome), following the HDC project's pattern, and adds a CI job that runs the full RSpec suite.

## Test infrastructure
- **Gems** (`group :test`): `capybara ~> 3.40`, `selenium-webdriver ~> 4.27.0` (pinned < 4.40, which requires Ruby 3.4; this app is on 3.3.0).
- **`spec/support/capybara.rb`** — registers `:headless_chrome`; `rack_test` for non-JS specs, `:headless_chrome` for `js: true`. selenium-manager auto-fetches chromedriver.
- **`spec/support/devise.rb`** — Warden `login_as user, scope: :user` for feature specs (`type: :feature`); `Devise::Test::IntegrationHelpers` for request specs. Explicit scope sidesteps the User→userable delegation issue on non-patient roles.
- **`spec/support/factory_bot.rb`** — `FactoryBot::Syntax::Methods` (bare `create`).
- Enabled the `spec/support/**` autoload glob in `rails_helper`.
- Transactional fixtures (no DatabaseCleaner) — verified rollback works and leaves no data behind.

## First feature spec
`spec/features/patient_state_spec.rb` drives a real browser: log in as an admin, visit `/patients`, click **Evaluar**, and assert the UI reflects the `prospect → candidate` transition. Verified green locally with Chrome 150.

## CI `test` job
Postgres 16 service → Ruby → Chrome (`browser-actions/setup-chrome`) → `dartsass:build` (builds `application.css`; resolves `@import "bootstrap"` via the gem, no Node) → `db:test:prepare` → `bundle exec rspec`.

## Also: made the suite fully green (was 8 pre-existing failures)
- `criteria_profiles` factory built a bare `:user`, which the delegated_type model now rejects → use the `:admin` trait.
- `trial_center_branches` scaffold view specs were divergent from the real app: bare `create!` without the required `trial_center_facility`, an assertion for a `facility_id` input the real form only renders conditionally, and the scaffold `div>p` selector vs the actual `.branch-card` layout.

**Local result:** 113 examples, 0 failures, 15 pending. RuboCop clean.