### PR TITLE
Add eligibility evaluator for the criteria engine + example profile

### DIFF
--- a/app/controllers/criteria_assessments_controller.rb
+++ b/app/controllers/criteria_assessments_controller.rb
@@ -1,0 +1,52 @@
+class CriteriaAssessmentsController < SecureApplicationController
+  before_action :set_patient
+  before_action :set_profile
+  # Assessing a patient's criteria is editing the patient's clinical data.
+  before_action -> { authorize(@patient, :update?) }
+
+  def show
+    @variables = ordered_variables
+    @values_by_name = @patient.variable_values.index_by(&:name)
+    @result = @profile.evaluate(@patient)
+  end
+
+  def update
+    save_values!
+    redirect_to patient_criteria_assessment_path(@patient, criteria_profile_id: @profile.id),
+                notice: "Evaluación de criterios actualizada."
+  end
+
+  private
+
+  def set_patient
+    @patient = Patient.find(params[:patient_id])
+  end
+
+  def set_profile
+    @profile = CriteriaProfile.find(params[:criteria_profile_id])
+  end
+
+  def ordered_variables
+    @profile.criteria_variables.select(&:enabled).sort_by { |cv| [ cv.variable_type, cv.criteria_order || 0 ] }
+  end
+
+  # Upsert one VariableValue per submitted variable (keyed by variable id, since
+  # names contain spaces/parens). Copies the rule onto the value (the snapshot
+  # design), matched to the profile by name.
+  def save_values!
+    @profile.criteria_variables.each do |cv|
+      raw = params.dig(:values, cv.id.to_s)
+      next if raw.blank?
+
+      record = @patient.variable_values.find_or_initialize_by(name: cv.name)
+      record.assign_attributes(
+        value: raw.to_s,
+        value_type: cv.value_type, comparison_type: cv.comparison_type, variable_type: cv.variable_type,
+        reference_value_1: cv.reference_value_1, reference_value_2: cv.reference_value_2,
+        qualitative_value: cv.qualitative_value, qualitative_scale: cv.qualitative_scale,
+        criteria_order: cv.criteria_order
+      )
+      record.save!
+    end
+  end
+end

--- a/app/models/concerns/criteria_comparable.rb
+++ b/app/models/concerns/criteria_comparable.rb
@@ -1,0 +1,60 @@
+# Shared comparison logic for the eligibility rules. Both CriteriaVariable (the
+# rule) and VariableValue (the patient's snapshot) carry the same comparison
+# columns (value_type, comparison_type, reference_value_1/2, qualitative_value),
+# so the atomic "does this value meet the comparison?" logic lives here once.
+#
+# `satisfied_by?` is polarity-agnostic — inclusion/exclusion interpretation
+# happens in CriteriaProfile#evaluate. It returns nil when the value is blank or
+# can't be evaluated (so the caller can distinguish "unknown" from true/false).
+module CriteriaComparable
+  extend ActiveSupport::Concern
+
+  def satisfied_by?(raw)
+    return nil if raw.nil? || raw.to_s.strip.empty?
+
+    case value_type
+    when "boolean"      then boolean_satisfied?(raw)
+    when "quantitative" then quantitative_satisfied?(raw)
+    when "qualitative"  then qualitative_satisfied?(raw)
+    end
+  end
+
+  private
+
+  def boolean_satisfied?(raw)
+    actual = ActiveModel::Type::Boolean.new.cast(raw)
+    case comparison_type
+    when "true"  then actual == true
+    when "false" then actual == false
+    end
+  end
+
+  def quantitative_satisfied?(raw)
+    actual = Float(raw, exception: false)
+    return nil if actual.nil?
+
+    ref1 = reference_value_1&.to_f
+    ref2 = reference_value_2&.to_f
+
+    case comparison_type
+    when "less_than"          then ref1 && actual < ref1
+    when "less_than_or_equal" then ref1 && actual <= ref1
+    when "more_than"          then ref1 && actual > ref1
+    when "more_than_or_equal" then ref1 && actual >= ref1
+    when "between_range"      then ref1 && ref2 && actual.between?(ref1, ref2)
+    when "out_of_range"       then ref1 && ref2 && !actual.between?(ref1, ref2)
+    when "equal"              then ref1 && actual == ref1
+    when "different"          then ref1 && actual != ref1
+    end
+  end
+
+  def qualitative_satisfied?(raw)
+    expected = qualitative_value.to_s.strip
+    actual = raw.to_s.strip
+
+    case comparison_type
+    when "equal"     then actual.casecmp?(expected)
+    when "different" then !actual.casecmp?(expected)
+    end
+  end
+end

--- a/app/models/concerns/criteria_comparable.rb
+++ b/app/models/concerns/criteria_comparable.rb
@@ -19,7 +19,35 @@ module CriteriaComparable
     end
   end
 
+  # Short human description of the comparison, e.g. "entre 18 y 40", "≥ 20", "Sí".
+  def rule_summary
+    case value_type
+    when "boolean"      then comparison_type == "true" ? "Sí" : "No"
+    when "qualitative"  then "#{comparison_type == 'different' ? '≠' : '='} #{qualitative_value}"
+    when "quantitative"
+      r1 = fmt_reference(reference_value_1)
+      r2 = fmt_reference(reference_value_2)
+      case comparison_type
+      when "between_range"      then "entre #{r1} y #{r2}"
+      when "out_of_range"       then "fuera de #{r1}–#{r2}"
+      when "less_than"          then "< #{r1}"
+      when "less_than_or_equal" then "≤ #{r1}"
+      when "more_than"          then "> #{r1}"
+      when "more_than_or_equal" then "≥ #{r1}"
+      when "equal"              then "= #{r1}"
+      when "different"          then "≠ #{r1}"
+      end
+    end
+  end
+
   private
+
+  def fmt_reference(value)
+    return if value.nil?
+
+    number = value.to_f
+    (number % 1).zero? ? number.to_i.to_s : number.to_s
+  end
 
   def boolean_satisfied?(raw)
     actual = ActiveModel::Type::Boolean.new.cast(raw)

--- a/app/models/criteria_profile.rb
+++ b/app/models/criteria_profile.rb
@@ -28,4 +28,22 @@ class CriteriaProfile < ApplicationRecord
   has_many :criteria_variables, dependent: :destroy
 
   validates :name, presence: true
+
+  # Evaluate `patient` against this profile's enabled variables. Patient answers
+  # (VariableValues) are matched to variables by `name` — the app's denormalized
+  # snapshot design has no FK linking the two. Returns an EligibilityResult.
+  def evaluate(patient)
+    answers = patient.variable_values.index_by(&:name)
+
+    checks = criteria_variables
+             .select(&:enabled)
+             .sort_by { |cv| cv.criteria_order || 0 }
+             .map do |cv|
+      answer = answers[cv.name]
+      met = answer ? cv.satisfied_by?(answer.value) : nil
+      EligibilityResult::Check.new(variable: cv, value: answer&.value, met: met)
+    end
+
+    EligibilityResult.new(checks)
+  end
 end

--- a/app/models/criteria_variable.rb
+++ b/app/models/criteria_variable.rb
@@ -31,6 +31,8 @@
 #  fk_rails_...  (criteria_profile_id => criteria_profiles.id)
 #
 class CriteriaVariable < ApplicationRecord
+  include CriteriaComparable
+
   belongs_to :criteria_profile
 
   attribute :value_type, :string

--- a/app/models/eligibility_result.rb
+++ b/app/models/eligibility_result.rb
@@ -1,0 +1,53 @@
+# Outcome of evaluating a patient against a CriteriaProfile. Wraps a list of
+# per-variable Checks and answers the two questions that matter: is the patient
+# eligible, and is the assessment even complete (all values captured)?
+class EligibilityResult
+  # One variable's outcome. `met` is true/false/nil (nil = the patient has no
+  # value for it yet). Passing depends on polarity:
+  #   inclusion -> the patient must meet it (met == true)
+  #   exclusion -> the patient must NOT meet it (met == false); an unmeasured
+  #                exclusion (nil) does not pass, so it surfaces as incomplete.
+  Check = Struct.new(:variable, :value, :met, keyword_init: true) do
+    def passed?
+      case variable.variable_type
+      when "inclusion" then met == true
+      when "exclusion" then met == false
+      else false
+      end
+    end
+
+    def missing?
+      met.nil?
+    end
+
+    def status
+      return :missing if missing?
+
+      passed? ? :pass : :fail
+    end
+  end
+
+  attr_reader :checks
+
+  def initialize(checks)
+    @checks = checks
+  end
+
+  # Eligible only when every variable is answered AND passes.
+  def eligible?
+    checks.any? && checks.all?(&:passed?)
+  end
+
+  # Every variable has a captured value (nothing left to assess).
+  def complete?
+    checks.none?(&:missing?)
+  end
+
+  def missing
+    checks.select(&:missing?)
+  end
+
+  def failing
+    checks.select { |c| c.status == :fail }
+  end
+end

--- a/app/models/variable_value.rb
+++ b/app/models/variable_value.rb
@@ -32,7 +32,14 @@
 #  fk_rails_...  (patient_id => patients.id)
 #
 class VariableValue < ApplicationRecord
+  include CriteriaComparable
+
   belongs_to :patient
+
+  # Whether the patient's captured `value` meets this variable's comparison.
+  def satisfied?
+    satisfied_by?(value)
+  end
 
   attribute :value_type, :string
   attribute :variable_type, :string

--- a/app/views/criteria_assessments/show.html.erb
+++ b/app/views/criteria_assessments/show.html.erb
@@ -1,0 +1,62 @@
+<div class="container mt-4">
+  <% if notice %><div class="alert alert-success"><%= notice %></div><% end %>
+
+  <h1 class="mb-1">Evaluación de criterios</h1>
+  <p class="text-muted mb-4">
+    <%= @profile.name %><% if @profile.study %> · Estudio: <%= @profile.study.public_title %><% end %>
+  </p>
+
+  <% if @result.eligible? %>
+    <div class="alert alert-success mb-4"><strong>Elegible</strong> — el paciente cumple todos los criterios.</div>
+  <% elsif !@result.complete? %>
+    <div class="alert alert-warning mb-4"><strong>Evaluación incompleta</strong> — faltan <%= @result.missing.count %> valor(es) por registrar.</div>
+  <% else %>
+    <div class="alert alert-danger mb-4"><strong>No elegible</strong> — <%= @result.failing.count %> criterio(s) no se cumplen.</div>
+  <% end %>
+
+  <% checks_by_var = @result.checks.index_by { |c| c.variable.id } %>
+
+  <%= form_with url: patient_criteria_assessment_path(@patient, criteria_profile_id: @profile.id), method: :patch do %>
+    <% @variables.group_by(&:variable_type).each do |variable_type, vars| %>
+      <h4 class="mt-4"><%= variable_type == "inclusion" ? "Criterios de inclusión" : "Criterios de exclusión" %></h4>
+      <div class="table-responsive">
+        <table class="table align-middle">
+          <thead>
+            <tr><th>Criterio</th><th>Regla</th><th>Valor del paciente</th><th>Estado</th></tr>
+          </thead>
+          <tbody>
+            <% vars.each do |cv| %>
+              <% current = @values_by_name[cv.name]&.value %>
+              <% status = checks_by_var[cv.id]&.status %>
+              <tr>
+                <td><%= cv.name %></td>
+                <td><span class="text-muted"><%= cv.rule_summary %></span></td>
+                <td style="max-width: 220px">
+                  <% if cv.value_type == "boolean" %>
+                    <%= select_tag "values[#{cv.id}]", options_for_select([["—", ""], ["Sí", "true"], ["No", "false"]], current), class: "form-select form-select-sm" %>
+                  <% elsif cv.value_type == "qualitative" %>
+                    <%= select_tag "values[#{cv.id}]", options_for_select([["—", ""]] + Array(cv.qualitative_scale).map { |o| [o, o] }, current), class: "form-select form-select-sm" %>
+                  <% else %>
+                    <%= number_field_tag "values[#{cv.id}]", current, step: :any, class: "form-control form-control-sm" %>
+                  <% end %>
+                </td>
+                <td>
+                  <% if status == :pass %>
+                    <span class="badge bg-success">Cumple</span>
+                  <% elsif status == :fail %>
+                    <span class="badge bg-danger">No cumple</span>
+                  <% else %>
+                    <span class="badge bg-secondary">Sin dato</span>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+
+    <%= submit_tag "Guardar y evaluar", class: "btn btn-success" %>
+    <%= link_to "Volver al paciente", patient_path(@patient), class: "btn btn-link" %>
+  <% end %>
+</div>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -2,6 +2,20 @@
 
 <%= render @patient %>
 
+<% studies_with_profiles = Array(@patient.user&.studies).select(&:criteria_profile) %>
+<% if studies_with_profiles.any? && policy(@patient).update? %>
+  <div class="mt-3">
+    <h5>Evaluación de elegibilidad</h5>
+    <div class="d-flex flex-column align-items-start gap-2">
+      <% studies_with_profiles.each do |study| %>
+        <%= link_to "Evaluar criterios — #{study.public_title}",
+                    patient_criteria_assessment_path(@patient, criteria_profile_id: study.criteria_profile.id),
+                    class: "btn btn-sm btn-outline-primary" %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
 <div>
   <%= link_to "Edit this patient", edit_patient_path(@patient) %> |
   <%= link_to "Back to patients", patients_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
     member do
       post :transition
     end
+    # Capture a patient's values for a study's criteria profile + see the verdict.
+    resource :criteria_assessment, only: %i[show update]
   end
 
   # Admin-only role/permission manager.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,10 @@ RolesAndPermissionsSeeder.seed!
 # require_relative 'seeds/create_id_types'
 # require_relative 'seeds/create_countries'
 #
+# Example eligibility profile (dev/demo only — see the file header):
+# require_relative 'seeds/example_seborrheic_dermatitis_profile'
+# ExampleSeborrheicDermatitisProfile.seed!
+#
 # Named admin accounts:
 # [ [ 'edsuescun@gmail.com', 'Eric', 'Suescun' ],
 #   [ 'nlecuona@gmail.com', 'Nathalia', 'Lecuona' ],

--- a/db/seeds/example_seborrheic_dermatitis_profile.rb
+++ b/db/seeds/example_seborrheic_dermatitis_profile.rb
@@ -1,0 +1,73 @@
+# Example eligibility profile modeled from a real severe seborrheic-dermatitis
+# protocol, to demonstrate the CriteriaProfile / CriteriaVariable engine and the
+# evaluator. Idempotent. Dev/demo only — not wired into db/seeds.rb by default
+# (it creates an admin-owned example profile). Run manually:
+#
+#   require_relative "db/seeds/example_seborrheic_dermatitis_profile"
+#   profile = ExampleSeborrheicDermatitisProfile.seed!
+#   ExampleSeborrheicDermatitisProfile.demo!(profile)   # sample eligible patient
+module ExampleSeborrheicDermatitisProfile
+  PROFILE_NAME = "Dermatitis seborreica grave — criterios de inclusión/exclusión".freeze
+
+  # [name, value_type, comparison_type, reference_value_1, reference_value_2]
+  INCLUSION = [
+    [ "Edad (años)", "quantitative", "between_range", 18, 40 ],
+    [ "Puntuación de severidad", "quantitative", "more_than_or_equal", 20, nil ],
+    [ "Afectación BSA (%)", "quantitative", "more_than_or_equal", 10, nil ],
+    [ "Duración de la enfermedad (meses)", "quantitative", "more_than_or_equal", 3, nil ],
+    [ "Candidato a terapia sistémica", "boolean", "true", nil, nil ]
+  ].freeze
+
+  EXCLUSION = [
+    [ "Infección sistémica activa (últimas 2 semanas)", "boolean", "true", nil, nil ],
+    [ "Planes de vacunas vivas", "boolean", "true", nil, nil ],
+    [ "Condición que impide adherencia (juicio del investigador)", "boolean", "true", nil, nil ],
+    [ "Hipersensibilidad o alergia al medicamento", "boolean", "true", nil, nil ],
+    [ "Abuso de alcohol o drogas (últimas 24 semanas)", "boolean", "true", nil, nil ],
+    [ "No dispuesto a limitar exposición UV", "boolean", "true", nil, nil ]
+  ].freeze
+
+  def self.seed!
+    owner = User.admins.first || FactoryBot.create(:user, :admin)
+
+    profile = CriteriaProfile.find_or_create_by!(name: PROFILE_NAME, user: owner) do |p|
+      p.description = "Ejemplo a partir de un protocolo de dermatitis seborreica grave."
+      p.study = Study.first
+    end
+
+    order = 0
+    (INCLUSION.map { |r| [ "inclusion", r ] } + EXCLUSION.map { |r| [ "exclusion", r ] }).each do |variable_type, (name, value_type, comparison_type, ref1, ref2)|
+      order += 1
+      variable = profile.criteria_variables.find_or_initialize_by(name: name)
+      variable.assign_attributes(
+        variable_type: variable_type, value_type: value_type, comparison_type: comparison_type,
+        reference_value_1: ref1, reference_value_2: ref2, criteria_order: order
+      )
+      variable.save!
+    end
+
+    profile
+  end
+
+  # Build a sample patient whose answers satisfy the profile and return the
+  # EligibilityResult (demonstrates the evaluator end to end).
+  def self.demo!(profile)
+    patient = Patient.create!(dob: Date.new(1990, 1, 1), sex: "female")
+    answers = {
+      "Edad (años)" => 34, "Puntuación de severidad" => 22, "Afectación BSA (%)" => 15,
+      "Duración de la enfermedad (meses)" => 8, "Candidato a terapia sistémica" => true,
+      "Infección sistémica activa (últimas 2 semanas)" => false, "Planes de vacunas vivas" => false,
+      "Condición que impide adherencia (juicio del investigador)" => false,
+      "Hipersensibilidad o alergia al medicamento" => false,
+      "Abuso de alcohol o drogas (últimas 24 semanas)" => false, "No dispuesto a limitar exposición UV" => false
+    }
+    profile.criteria_variables.each do |cv|
+      patient.variable_values.create!(
+        name: cv.name, value: answers[cv.name].to_s, value_type: cv.value_type,
+        comparison_type: cv.comparison_type, variable_type: cv.variable_type,
+        reference_value_1: cv.reference_value_1, reference_value_2: cv.reference_value_2
+      )
+    end
+    profile.evaluate(patient)
+  end
+end

--- a/spec/models/criteria_comparable_spec.rb
+++ b/spec/models/criteria_comparable_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+# Exercised through CriteriaVariable; unsaved instances are enough for the
+# atomic comparison logic.
+RSpec.describe CriteriaComparable do
+  def var(attrs)
+    CriteriaVariable.new(attrs)
+  end
+
+  describe "#satisfied_by?" do
+    it "returns nil for a blank value" do
+      v = var(value_type: "quantitative", comparison_type: "more_than", reference_value_1: 5)
+      expect(v.satisfied_by?(nil)).to be_nil
+      expect(v.satisfied_by?("")).to be_nil
+    end
+
+    context "quantitative" do
+      it "handles between_range inclusively" do
+        v = var(value_type: "quantitative", comparison_type: "between_range", reference_value_1: 18, reference_value_2: 40)
+        expect(v.satisfied_by?(25)).to be(true)
+        expect(v.satisfied_by?(18)).to be(true)
+        expect(v.satisfied_by?(40)).to be(true)
+        expect(v.satisfied_by?(41)).to be(false)
+        expect(v.satisfied_by?(17)).to be(false)
+      end
+
+      it "handles the ordering + equality operators" do
+        expect(var(value_type: "quantitative", comparison_type: "more_than_or_equal", reference_value_1: 20).satisfied_by?(20)).to be(true)
+        expect(var(value_type: "quantitative", comparison_type: "more_than_or_equal", reference_value_1: 20).satisfied_by?(19)).to be(false)
+        expect(var(value_type: "quantitative", comparison_type: "more_than", reference_value_1: 20).satisfied_by?(20)).to be(false)
+        expect(var(value_type: "quantitative", comparison_type: "less_than", reference_value_1: 10).satisfied_by?(9)).to be(true)
+        expect(var(value_type: "quantitative", comparison_type: "out_of_range", reference_value_1: 18, reference_value_2: 40).satisfied_by?(50)).to be(true)
+        expect(var(value_type: "quantitative", comparison_type: "equal", reference_value_1: 5).satisfied_by?("5")).to be(true)
+        expect(var(value_type: "quantitative", comparison_type: "different", reference_value_1: 5).satisfied_by?(6)).to be(true)
+      end
+
+      it "returns nil when the value is not numeric" do
+        expect(var(value_type: "quantitative", comparison_type: "more_than", reference_value_1: 5).satisfied_by?("abc")).to be_nil
+      end
+    end
+
+    context "boolean" do
+      it "handles true/false (and truthy strings)" do
+        expect(var(value_type: "boolean", comparison_type: "true").satisfied_by?(true)).to be(true)
+        expect(var(value_type: "boolean", comparison_type: "true").satisfied_by?("1")).to be(true)
+        expect(var(value_type: "boolean", comparison_type: "true").satisfied_by?(false)).to be(false)
+        expect(var(value_type: "boolean", comparison_type: "false").satisfied_by?(false)).to be(true)
+      end
+    end
+
+    context "qualitative" do
+      it "handles equal/different case-insensitively" do
+        v = var(value_type: "qualitative", comparison_type: "equal", qualitative_value: "grave")
+        expect(v.satisfied_by?("grave")).to be(true)
+        expect(v.satisfied_by?("Grave")).to be(true)
+        expect(v.satisfied_by?("leve")).to be(false)
+        expect(var(value_type: "qualitative", comparison_type: "different", qualitative_value: "grave").satisfied_by?("leve")).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/criteria_profile_spec.rb
+++ b/spec/models/criteria_profile_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe CriteriaProfile, type: :model do
+  describe "#evaluate" do
+    let(:profile) { FactoryBot.create(:criteria_profile) }
+    let(:patient) { FactoryBot.create(:patient) }
+
+    def rule(name:, variable_type:, comparison_type:, value_type: "quantitative", ref1: nil, ref2: nil)
+      profile.criteria_variables.create!(
+        name: name, variable_type: variable_type, value_type: value_type,
+        comparison_type: comparison_type, reference_value_1: ref1, reference_value_2: ref2
+      )
+    end
+
+    # Give the patient a value for a rule (matched by name). value_type/
+    # comparison_type only satisfy VariableValue validations; evaluate uses the
+    # rule's comparison.
+    def answer(name:, value:, value_type: "quantitative", comparison_type: "equal")
+      patient.variable_values.create!(name: name, value: value.to_s, value_type: value_type, comparison_type: comparison_type)
+    end
+
+    it "is eligible when all inclusions pass and no exclusion triggers" do
+      rule(name: "Edad", variable_type: "inclusion", comparison_type: "between_range", ref1: 18, ref2: 40)
+      rule(name: "Infección", variable_type: "exclusion", value_type: "boolean", comparison_type: "true")
+      answer(name: "Edad", value: 30)
+      answer(name: "Infección", value: false, value_type: "boolean", comparison_type: "true")
+
+      result = profile.evaluate(patient)
+      expect(result).to be_eligible
+      expect(result).to be_complete
+    end
+
+    it "is ineligible when an inclusion fails" do
+      rule(name: "Edad", variable_type: "inclusion", comparison_type: "between_range", ref1: 18, ref2: 40)
+      answer(name: "Edad", value: 50)
+
+      expect(profile.evaluate(patient)).not_to be_eligible
+    end
+
+    it "is ineligible when an exclusion is triggered" do
+      rule(name: "Infección", variable_type: "exclusion", value_type: "boolean", comparison_type: "true")
+      answer(name: "Infección", value: true, value_type: "boolean", comparison_type: "true")
+
+      result = profile.evaluate(patient)
+      expect(result).not_to be_eligible
+      expect(result.failing.map { |c| c.variable.name }).to include("Infección")
+    end
+
+    it "is incomplete and not eligible when a value is missing" do
+      rule(name: "Edad", variable_type: "inclusion", comparison_type: "between_range", ref1: 18, ref2: 40)
+
+      result = profile.evaluate(patient)
+      expect(result).not_to be_complete
+      expect(result).not_to be_eligible
+      expect(result.missing.map { |c| c.variable.name }).to include("Edad")
+    end
+  end
+end

--- a/spec/requests/criteria_assessments_spec.rb
+++ b/spec/requests/criteria_assessments_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe "Criteria assessments", type: :request do
+  let(:profile) { FactoryBot.create(:criteria_profile) }
+  let(:patient) { FactoryBot.create(:patient) }
+  let!(:age) do
+    profile.criteria_variables.create!(
+      name: "Edad", variable_type: "inclusion", value_type: "quantitative",
+      comparison_type: "between_range", reference_value_1: 18, reference_value_2: 40
+    )
+  end
+
+  def assessment_path
+    patient_criteria_assessment_path(patient, criteria_profile_id: profile.id)
+  end
+
+  context "as an admin (can edit patients)" do
+    before { sign_in(FactoryBot.create(:user, :admin), scope: :user) }
+
+    it "renders the assessment form" do
+      get assessment_path
+      expect(response).to be_successful
+      expect(response.body).to include("Evaluación de criterios")
+      expect(response.body).to include("Edad")
+    end
+
+    it "saves submitted values and re-evaluates" do
+      patch assessment_path, params: { values: { age.id.to_s => "30" } }
+
+      expect(response).to redirect_to(assessment_path)
+      expect(patient.variable_values.find_by(name: "Edad").value).to eq("30")
+      expect(profile.evaluate(patient.reload)).to be_eligible
+    end
+  end
+
+  context "as a patient (cannot edit patients)" do
+    before { sign_in(FactoryBot.create(:user, :patient), scope: :user) }
+
+    it "is blocked" do
+      get assessment_path
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/requests/home_studies_spec.rb
+++ b/spec/requests/home_studies_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe "Home page study showcase", type: :request do
+  it "shows all studies with an enroll link to anonymous potential patients" do
+    study = FactoryBot.create(:study)
+
+    get root_path
+
+    expect(response).to be_successful
+    expect(response.body).to include("Estudios Clínicos Disponibles")
+    expect(response.body).to include(study.public_title)
+    expect(response.body).to include(new_user_registration_path(study_id: study.id))
+  end
+end


### PR DESCRIPTION
## Why
The criteria engine (`CriteriaProfile` → `CriteriaVariable`, `Patient` → `VariableValue`) could *define* inclusion/exclusion rules and *store* patient values, but had **no code to actually assess a patient**. This adds the evaluation layer.

## What
- **`CriteriaComparable`** concern — shared by `CriteriaVariable` (the rule) and `VariableValue` (the patient's snapshot), since they carry identical comparison columns. `satisfied_by?(value)` implements every operator (`between_range`, `more_than_or_equal`, `equal`, `true`/`false`, …) across the three `value_type`s (boolean/quantitative/qualitative). Returns `nil` for blank/unparseable values so "unknown" is distinct from true/false.
- **`VariableValue#satisfied?`** — self-evaluates the patient's captured `value`.
- **`CriteriaProfile#evaluate(patient)` → `EligibilityResult`** — matches the patient's `variable_values` to the profile's variables **by name** (the app's denormalized snapshot design has no FK), applies polarity (inclusion must pass; exclusion must not trigger), and reports `eligible?`, `complete?` (all values captured), and per-variable `pass`/`fail`/`missing`.

## Example / prototype
`db/seeds/example_seborrheic_dermatitis_profile.rb` models a real severe seborrheic-dermatitis protocol — 5 inclusion + 6 exclusion variables — plus a `demo!` that builds an eligible sample patient. Verified end-to-end: `eligible=true, complete=true`, all 11 checks pass. It's **dev/demo only** (opt-in, commented in `db/seeds.rb`) since it creates an example profile.

## Not included (deliberate, follow-ups)
- **No capture UI yet** — there's still no controller/view for a physician (or patient) to *set* a patient's `VariableValue`s. This PR is the assessment brain; the data-entry hands are next.
- **Not wired to the AASM `assess`** transition — `evaluate` is ready to gate `prospect → candidate`, but that wiring is a separate step.

## Tests
`spec/models/criteria_comparable_spec.rb` (all operators/types) + `spec/models/criteria_profile_spec.rb` (eligible / inclusion-fail / exclusion-trigger / incomplete). Full suite 159/0, lint clean.