### PR TITLE
Add PaperTrail audit trail + user attribution to patient data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ Each item below is a task to execute, not just a gem to install — most gaps ne
 - [x] 6. **[HIGH] Wire the audit trail.** _(2026-07-13 — branch `MA-variable-value-attribution`.)_
    - Gem: none new — `paper_trail` is already in the Gemfile.
    - Dev work: declare `has_paper_trail` on `Patient`, `CriteriaVariable`, `Study`, and any other model holding clinical/eligibility data.
-   - **Done:** installed PaperTrail (`versions` table), wired `set_paper_trail_whodunnit` in `ApplicationController` (PaperTrail 15 no longer auto-installs it) so every change records the acting user, and declared `has_paper_trail` on `Patient`, `VariableValue`, `CriteriaVariable`, `CriteriaProfile`. Also added an `entered_by` user FK on `VariableValue` (first-capture attribution). **Not covered:** `Study` — intentionally left out (not patient data); add `has_paper_trail` to `Study` if full Task-6 scope is wanted.
+   - **Done:** installed PaperTrail (`versions` table), wired `set_paper_trail_whodunnit` in `ApplicationController` (PaperTrail 15 no longer auto-installs it) so every change records the acting user, and declared `has_paper_trail` on `Patient`, `VariableValue`, `CriteriaVariable`, `CriteriaProfile`, and `Study`. Also added an `entered_by` user FK on `VariableValue` (first-capture attribution).
 
 - [ ] 7. **[MEDIUM] Add a cross-border transfer safeguard for international `Sponsor`s.**
    - Gem: none — this is a process/legal control (data transfer agreements, explicit consent language), not a technical one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,9 +222,10 @@ Each item below is a task to execute, not just a gem to install — most gaps ne
    - Gem: none new — use Rails 8's native `ActiveRecord::Encryption`.
    - Dev work: encrypt identifiable clinical fields (`illness_description`, `dob`, etc.) that feed into study/eligibility data, and add a participant-code column (`SecureRandom`-backed) so research data can be linked to identity only via that code, per the secure-storage requirement.
 
-- [ ] 6. **[HIGH] Wire the audit trail.**
+- [x] 6. **[HIGH] Wire the audit trail.** _(2026-07-13 — branch `MA-variable-value-attribution`.)_
    - Gem: none new — `paper_trail` is already in the Gemfile.
    - Dev work: declare `has_paper_trail` on `Patient`, `CriteriaVariable`, `Study`, and any other model holding clinical/eligibility data.
+   - **Done:** installed PaperTrail (`versions` table), wired `set_paper_trail_whodunnit` in `ApplicationController` (PaperTrail 15 no longer auto-installs it) so every change records the acting user, and declared `has_paper_trail` on `Patient`, `VariableValue`, `CriteriaVariable`, `CriteriaProfile`. Also added an `entered_by` user FK on `VariableValue` (first-capture attribution). **Not covered:** `Study` — intentionally left out (not patient data); add `has_paper_trail` to `Study` if full Task-6 scope is wanted.
 
 - [ ] 7. **[MEDIUM] Add a cross-border transfer safeguard for international `Sponsor`s.**
    - Gem: none — this is a process/legal control (data transfer agreements, explicit consent language), not a technical one.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
+  # PaperTrail no longer auto-installs this; wire whodunnit to the acting user so
+  # every audited change is attributable. `user_for_paper_trail` defaults to
+  # current_user.id (nil for unauthenticated requests).
+  before_action :set_paper_trail_whodunnit
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/app/controllers/criteria_assessments_controller.rb
+++ b/app/controllers/criteria_assessments_controller.rb
@@ -39,6 +39,9 @@ class CriteriaAssessmentsController < SecureApplicationController
       next if raw.blank?
 
       record = @patient.variable_values.find_or_initialize_by(name: cv.name)
+      # Attribute the first capture to the acting user; later edits are tracked by
+      # PaperTrail's whodunnit, so we don't overwrite the original recorder here.
+      record.entered_by ||= current_user
       record.assign_attributes(
         value: raw.to_s,
         value_type: cv.value_type, comparison_type: cv.comparison_type, variable_type: cv.variable_type,

--- a/app/models/criteria_profile.rb
+++ b/app/models/criteria_profile.rb
@@ -22,6 +22,9 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class CriteriaProfile < ApplicationRecord
+  # Audit trail for the eligibility rule set (changes ripple to patient verdicts).
+  has_paper_trail
+
   belongs_to :study, optional: true
   belongs_to :user
 

--- a/app/models/criteria_variable.rb
+++ b/app/models/criteria_variable.rb
@@ -33,6 +33,9 @@
 class CriteriaVariable < ApplicationRecord
   include CriteriaComparable
 
+  # Audit trail: eligibility rules feed a patient's verdict, so changes are versioned.
+  has_paper_trail
+
   belongs_to :criteria_profile
 
   attribute :value_type, :string

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -26,6 +26,10 @@
 class Patient < ApplicationRecord
   include Userable
 
+  # Audit trail for the patient's personal/clinical data and AASM state changes;
+  # whodunnit records the acting user (see PaperTrail controller integration).
+  has_paper_trail
+
   has_many :variable_values, dependent: :destroy
 
   include AASM

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -32,6 +32,9 @@
 #  fk_rails_...  (sponsor_id => sponsors.id)
 #
 class Study < ApplicationRecord
+  # Audit trail: study status/phase changes affect enrolled patients' eligibility.
+  has_paper_trail
+
   belongs_to :sponsor
 
   has_and_belongs_to_many :trial_center_branches

--- a/app/models/variable_value.rb
+++ b/app/models/variable_value.rb
@@ -20,21 +20,32 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  patient_id        :bigint           not null
+#  entered_by_id     :bigint
 #
 # Indexes
 #
+#  index_variable_values_on_entered_by_id        (entered_by_id)
 #  index_variable_values_on_patient_id           (patient_id)
 #  index_variable_values_on_patient_id_and_name  (patient_id,name)
 #  index_vv_on_patient_type_order                (patient_id,variable_type,criteria_order)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (entered_by_id => users.id)
 #  fk_rails_...  (patient_id => patients.id)
 #
 class VariableValue < ApplicationRecord
   include CriteriaComparable
 
+  # Audit trail: every create/update/destroy is versioned, and whodunnit records
+  # the acting user (see PaperTrail controller integration).
+  has_paper_trail
+
   belongs_to :patient
+  # The user (physician) who captured this value. Optional: existing/seeded rows
+  # may have none. PaperTrail's whodunnit tracks *every* change; entered_by is the
+  # convenient "who first recorded it" reference on the row itself.
+  belongs_to :entered_by, class_name: "User", optional: true
 
   # Whether the patient's captured `value` meets this variable's comparison.
   def satisfied?

--- a/db/migrate/20260713153856_create_versions.rb
+++ b/db/migrate/20260713153856_create_versions.rb
@@ -1,0 +1,40 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[8.0]
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      # Consider using bigint type for performance if you are going to store only numeric ids.
+      # t.bigint   :whodunnit
+      t.string   :whodunnit
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+
+      t.bigint   :item_id,   null: false
+      t.string   :item_type, null: false
+      t.string   :event,     null: false
+      t.text     :object, limit: TEXT_BYTES
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20260713153908_add_entered_by_to_variable_values.rb
+++ b/db/migrate/20260713153908_add_entered_by_to_variable_values.rb
@@ -1,0 +1,8 @@
+class AddEnteredByToVariableValues < ActiveRecord::Migration[8.0]
+  def change
+    # Who captured this patient value. Nullable: existing rows predate attribution,
+    # and a value may be seeded/imported without a signed-in user.
+    add_reference :variable_values, :entered_by, null: true,
+                  foreign_key: { to_table: :users }, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_12_140004) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_153908) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -328,9 +328,21 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_12_140004) do
     t.string "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "entered_by_id"
+    t.index ["entered_by_id"], name: "index_variable_values_on_entered_by_id"
     t.index ["patient_id", "name"], name: "index_variable_values_on_patient_id_and_name"
     t.index ["patient_id", "variable_type", "criteria_order"], name: "index_vv_on_patient_type_order"
     t.index ["patient_id"], name: "index_variable_values_on_patient_id"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "whodunnit"
+    t.datetime "created_at"
+    t.bigint "item_id", null: false
+    t.string "item_type", null: false
+    t.string "event", null: false
+    t.text "object"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "articles", "studies"
@@ -347,4 +359,5 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_12_140004) do
   add_foreign_key "trial_cities", "studies"
   add_foreign_key "users", "roles"
   add_foreign_key "variable_values", "patients"
+  add_foreign_key "variable_values", "users", column: "entered_by_id"
 end

--- a/spec/models/paper_trail_audit_spec.rb
+++ b/spec/models/paper_trail_audit_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe "PaperTrail audit trail on patient-related models", type: :model 
     expect { profile.update!(name: "Updated profile") }
       .to change { profile.versions.count }.by(1)
   end
+
+  it "versions a Study (status/phase changes affect eligibility)" do
+    study = FactoryBot.create(:study)
+    expect { study.update!(study_status: "completed") }
+      .to change { study.versions.count }.by(1)
+  end
 end

--- a/spec/models/paper_trail_audit_spec.rb
+++ b/spec/models/paper_trail_audit_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+# Every model holding patient-related data must be versioned so all changes are
+# traceable (INVIMA / Resolución 1995 audit-attribution requirement).
+RSpec.describe "PaperTrail audit trail on patient-related models", type: :model do
+  it "versions a Patient on create and update" do
+    patient = FactoryBot.create(:patient)
+    expect { patient.update!(notes: "seen in clinic") }
+      .to change { patient.versions.count }.by(1)
+  end
+
+  it "versions a VariableValue and can attribute it to a user" do
+    patient = FactoryBot.create(:patient)
+    physician = FactoryBot.create(:user, :admin)
+    value = patient.variable_values.create!(
+      name: "Edad", value_type: "quantitative", comparison_type: "equal",
+      variable_type: "inclusion", value: "30", entered_by: physician
+    )
+
+    expect(value.versions).to be_present
+    expect(value.entered_by).to eq(physician)
+  end
+
+  it "versions a CriteriaVariable (an eligibility rule change)" do
+    profile = FactoryBot.create(:criteria_profile)
+    variable = FactoryBot.create(:criteria_variable, criteria_profile: profile)
+    expect { variable.update!(reference_value_1: 21) }
+      .to change { variable.versions.count }.by(1)
+  end
+
+  it "versions a CriteriaProfile" do
+    profile = FactoryBot.create(:criteria_profile)
+    expect { profile.update!(name: "Updated profile") }
+      .to change { profile.versions.count }.by(1)
+  end
+end

--- a/spec/requests/criteria_assessments_spec.rb
+++ b/spec/requests/criteria_assessments_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "Criteria assessments", type: :request do
   end
 
   context "as an admin (can edit patients)" do
-    before { sign_in(FactoryBot.create(:user, :admin), scope: :user) }
+    let(:admin_user) { FactoryBot.create(:user, :admin) }
+    before { sign_in(admin_user, scope: :user) }
 
     it "renders the assessment form" do
       get assessment_path
@@ -30,6 +31,15 @@ RSpec.describe "Criteria assessments", type: :request do
       expect(response).to redirect_to(assessment_path)
       expect(patient.variable_values.find_by(name: "Edad").value).to eq("30")
       expect(profile.evaluate(patient.reload)).to be_eligible
+    end
+
+    it "attributes the captured value to the acting user and versions the change" do
+      patch assessment_path, params: { values: { age.id.to_s => "30" } }
+
+      value = patient.variable_values.find_by(name: "Edad")
+      expect(value.entered_by).to eq(admin_user)
+      # PaperTrail records the change with the acting user as whodunnit.
+      expect(value.versions.last.whodunnit).to eq(admin_user.id.to_s)
     end
   end
 


### PR DESCRIPTION
## Summary

Closes the standing **Task 6** gap in `CLAUDE.md`: `paper_trail` was in the Gemfile but declared on **zero models**, so no patient/eligibility change was traceable. This branch installs it, wires user attribution, and versions every clinical/eligibility model — satisfying the INVIMA / Resolución 1995 audit-attribution requirement (every change traceable to a patient *and* to the acting user).

## What's included

- **Install PaperTrail** — creates the `versions` table.
- **Whodunnit wiring** — `set_paper_trail_whodunnit` in `ApplicationController`. PaperTrail 15 no longer auto-installs this, so without it whodunnit was `nil`; now every audited change records `current_user`.
- **`has_paper_trail`** on `Patient`, `VariableValue`, `CriteriaVariable`, `CriteriaProfile`, and `Study` — the patient's data plus the eligibility rules (and study status/phase) that drive a patient's verdict.
- **`entered_by` user FK** (nullable) on `VariableValue`; `CriteriaAssessmentsController` sets it to the acting physician on first capture (`||=`, so the original recorder is preserved and later edits are still tracked via whodunnit).

## Migrations

⚠️ Adds **two new migrations** (`create_versions`, `add_entered_by_to_variable_values`) — production deploy will need `heroku run rails db:migrate`.

## Testing

- Request spec asserts both `entered_by` and whodunnit attribution on capture.
- New model spec verifies all five models are versioned.
- Full suite: **168 examples, 0 failures, 15 pending** (pending = pre-existing scaffold placeholders). RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)