### PR TITLE
Admin-only Change Control (audit log) view over tracked models

### DIFF
--- a/app/controllers/change_controls_controller.rb
+++ b/app/controllers/change_controls_controller.rb
@@ -1,0 +1,85 @@
+require "csv"
+
+class ChangeControlsController < SecureApplicationController
+  # Whitelist of audited models exposed through the change-control view, keyed by
+  # the param value so an arbitrary class name can never be constantized from input.
+  TRACKED_MODELS = {
+    "Patient" => Patient,
+    "Study" => Study,
+    "CriteriaProfile" => CriteriaProfile,
+    "CriteriaVariable" => CriteriaVariable,
+    "VariableValue" => VariableValue
+  }.freeze
+
+  def show
+    @item = find_item
+    authorize @item, :show?, policy_class: ChangeControlPolicy
+
+    # Editors are drawn from ALL versions (not the filtered set) so the user filter
+    # always lists everyone who ever touched the record.
+    @editors = editors_for(@item)
+    @versions = filtered_versions
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        send_data change_control_csv(@versions, @editors),
+                  filename: "change-control-#{params[:item_type].underscore}-#{@item.id}.csv"
+      end
+    end
+  end
+
+  private
+
+  def find_item
+    klass = TRACKED_MODELS[params[:item_type]]
+    raise ActiveRecord::RecordNotFound, "Untracked type" unless klass
+
+    klass.find(params[:item_id])
+  end
+
+  # Apply the optional filters: event type, acting user (whodunnit), and date range.
+  def filtered_versions
+    scope = @item.versions.reorder(created_at: :desc, id: :desc)
+    scope = scope.where(event: params[:event]) if params[:event].present?
+    scope = scope.where(whodunnit: params[:whodunnit]) if params[:whodunnit].present?
+    if (from = parse_date(params[:from]))
+      scope = scope.where(created_at: from.beginning_of_day..)
+    end
+    if (to = parse_date(params[:to]))
+      scope = scope.where(created_at: ..to.end_of_day)
+    end
+    scope
+  end
+
+  def editors_for(item)
+    ids = item.versions.reorder(nil).distinct.pluck(:whodunnit).compact
+    User.where(id: ids).index_by { |u| u.id.to_s }
+  end
+
+  def parse_date(str)
+    return nil if str.blank?
+
+    Date.parse(str)
+  rescue ArgumentError
+    nil
+  end
+
+  def change_control_csv(versions, editors)
+    CSV.generate(headers: true) do |csv|
+      csv << %w[fecha evento usuario campo antes despues]
+      versions.each do |version|
+        editor = editors[version.whodunnit]
+        who = editor ? (editor.fullname.presence || editor.email) : version.whodunnit
+        changes = helpers.change_control_diff(version)
+        if changes.empty?
+          csv << [ version.created_at, version.event, who, nil, nil, nil ]
+        else
+          changes.each do |attr, (old_val, new_val)|
+            csv << [ version.created_at, version.event, who, attr, old_val, new_val ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/change_controls_helper.rb
+++ b/app/helpers/change_controls_helper.rb
@@ -1,0 +1,37 @@
+module ChangeControlsHelper
+  # Attributes not worth showing in a change diff (always-present, low-signal).
+  IGNORED_CHANGE_KEYS = %w[updated_at created_at].freeze
+
+  # The meaningful field-level changes for a version, as { attr => [old, new] },
+  # with noise (timestamps) stripped. Returns {} when nothing survives.
+  def change_control_diff(version)
+    (version.changeset || {}).except(*IGNORED_CHANGE_KEYS)
+  end
+
+  # Render one side of a diff for display: nil as an em-dash, arrays joined,
+  # everything else as a plain string.
+  def change_control_value(value)
+    return content_tag(:span, "∅", class: "text-muted") if value.nil?
+    return content_tag(:span, "(vacío)", class: "text-muted") if value.respond_to?(:empty?) && value.empty?
+
+    display = value.is_a?(Array) ? value.join(", ") : value.to_s
+    truncate(display, length: 120)
+  end
+
+  # Bootstrap badge colour for a PaperTrail event.
+  def change_control_event_badge(event)
+    { "create" => "success", "update" => "primary", "destroy" => "danger" }.fetch(event, "secondary")
+  end
+
+  # Human name for the acting user behind a version's whodunnit, using a
+  # preloaded { id_string => User } map.
+  def change_control_editor_name(version, editors)
+    if (editor = editors[version.whodunnit])
+      editor.fullname.presence || editor.email
+    elsif version.whodunnit.present?
+      content_tag(:span, "Usuario ##{version.whodunnit} (eliminado)", class: "text-muted")
+    else
+      content_tag(:span, "Sistema / sin sesión", class: "text-muted")
+    end
+  end
+end

--- a/app/policies/change_control_policy.rb
+++ b/app/policies/change_control_policy.rb
@@ -1,0 +1,8 @@
+# Change-control (audit) view is admin-only *for now* — intentionally stricter
+# than the per-resource `can_show` permission that ApplicationPolicy grants. When
+# other roles should see the change log, widen this single method.
+class ChangeControlPolicy < ApplicationPolicy
+  def show?
+    !!user&.admin?
+  end
+end

--- a/app/views/change_controls/show.html.erb
+++ b/app/views/change_controls/show.html.erb
@@ -1,0 +1,87 @@
+<% item_label = "#{params[:item_type]} ##{@item.id}" %>
+<% content_for :title, "Control de cambios — #{item_label}" %>
+<% base_path = change_control_path(params[:item_type], @item.id) %>
+
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h3 class="mb-0">Control de cambios <small class="text-muted">— <%= item_label %></small></h3>
+    <div class="d-flex gap-2">
+      <%= link_to "Exportar CSV",
+                  change_control_path(params[:item_type], @item.id,
+                    format: :csv, event: params[:event], whodunnit: params[:whodunnit],
+                    from: params[:from], to: params[:to]),
+                  class: "btn btn-sm btn-outline-success" %>
+      <%= link_to "Volver", :back, class: "btn btn-sm btn-outline-secondary" %>
+    </div>
+  </div>
+
+  <%= form_with url: base_path, method: :get, class: "row g-2 align-items-end mb-3" do |f| %>
+    <div class="col-auto">
+      <%= label_tag :event, "Evento", class: "form-label mb-0 small" %>
+      <%= select_tag :event,
+            options_for_select([ [ "Todos", "" ], [ "Creación", "create" ], [ "Actualización", "update" ], [ "Eliminación", "destroy" ] ], params[:event]),
+            class: "form-select form-select-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= label_tag :whodunnit, "Usuario", class: "form-label mb-0 small" %>
+      <%= select_tag :whodunnit,
+            options_for_select([ [ "Todos", "" ] ] + @editors.values.map { |u| [ (u.fullname.presence || u.email), u.id.to_s ] }, params[:whodunnit]),
+            class: "form-select form-select-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= label_tag :from, "Desde", class: "form-label mb-0 small" %>
+      <%= date_field_tag :from, params[:from], class: "form-control form-control-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= label_tag :to, "Hasta", class: "form-label mb-0 small" %>
+      <%= date_field_tag :to, params[:to], class: "form-control form-control-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= submit_tag "Filtrar", class: "btn btn-sm btn-primary" %>
+      <%= link_to "Limpiar", base_path, class: "btn btn-sm btn-outline-secondary" %>
+    </div>
+  <% end %>
+
+  <% if @versions.empty? %>
+    <div class="alert alert-info">No hay cambios que coincidan con los filtros.</div>
+  <% else %>
+    <div class="table-responsive">
+      <table class="table table-sm table-striped align-middle">
+        <thead>
+          <tr>
+            <th class="text-nowrap">Fecha</th>
+            <th>Evento</th>
+            <th>Usuario</th>
+            <th>Cambios</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @versions.each do |version| %>
+            <tr>
+              <td class="text-nowrap"><%= version.created_at&.strftime("%Y-%m-%d %H:%M") %></td>
+              <td><span class="badge bg-<%= change_control_event_badge(version.event) %>"><%= version.event %></span></td>
+              <td><%= change_control_editor_name(version, @editors) %></td>
+              <td>
+                <% diff = change_control_diff(version) %>
+                <% if diff.empty? %>
+                  <span class="text-muted">—</span>
+                <% else %>
+                  <ul class="mb-0 ps-3 small">
+                    <% diff.each do |attr, (old_val, new_val)| %>
+                      <li>
+                        <strong><%= attr.humanize %>:</strong>
+                        <%= change_control_value(old_val) %>
+                        &rarr;
+                        <%= change_control_value(new_val) %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/criteria_profiles/show.html.erb
+++ b/app/views/criteria_profiles/show.html.erb
@@ -8,6 +8,9 @@
       <div class="mt-3">
         <%= link_to "Editar", edit_criteria_profile_path(@criteria_profile) %> |
         <%= link_to "Retornar a Perfiles", criteria_profiles_path %>
+        <% if current_user&.admin? %>
+          | <%= link_to "Control de cambios", change_control_path("CriteriaProfile", @criteria_profile.id) %>
+        <% end %>
 
         <%= button_to "Borrar", @criteria_profile, method: :delete, class: "btn btn-primary btn-block mt-3 mb-3" %>
       </div>

--- a/app/views/criteria_variables/show.html.erb
+++ b/app/views/criteria_variables/show.html.erb
@@ -8,6 +8,9 @@
       <div class="mt-3">
         <%= link_to "Editar", edit_criteria_profile_criteria_variable_path(@criteria_profile, @criteria_variable) %> |
         <%= link_to "Retornar a Variables", criteria_profile_criteria_variables_path(@criteria_profile) %>
+        <% if current_user&.admin? %>
+          | <%= link_to "Control de cambios", change_control_path("CriteriaVariable", @criteria_variable.id) %>
+        <% end %>
 
         <%= button_to "Borrar", [@criteria_profile, @criteria_variable], method: :delete, class: "btn btn-primary btn-block mt-3 mb-3" %>
       </div>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -19,6 +19,9 @@
 <div>
   <%= link_to "Edit this patient", edit_patient_path(@patient) %> |
   <%= link_to "Back to patients", patients_path %>
+  <% if current_user&.admin? %>
+    | <%= link_to "Control de cambios", change_control_path("Patient", @patient.id) %>
+  <% end %>
 
   <%= button_to "Destroy this patient", @patient, method: :delete %>
 </div>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -5,6 +5,9 @@
       <div>
         <%= link_to "Editar este estudio", edit_study_path(@study) %> |
         <%= link_to "Retornar a Estudios", studies_path %>
+        <% if current_user&.admin? %>
+          | <%= link_to "Control de cambios", change_control_path("Study", @study.id) %>
+        <% end %>
 
         <%= button_to "Borrar", @study, method: :delete, class: "btn btn-primary btn-block mt-3 mb-3" %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,9 @@ Rails.application.routes.draw do
   resources :criteria_profiles do
     resources :criteria_variables
   end
+
+  # Admin-only change-control (audit) log for any PaperTrail-tracked model.
+  get "change-control/:item_type/:item_id", to: "change_controls#show", as: :change_control
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260713160019_add_object_changes_to_versions.rb
+++ b/db/migrate/20260713160019_add_object_changes_to_versions.rb
@@ -1,0 +1,11 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration[8.0]
+  # PaperTrail populates this automatically when present, letting the change-control
+  # view show field-level diffs (what changed), not just who/when.
+  #
+  # jsonb (not text): PaperTrail then stores/reads the changeset as JSON instead of
+  # YAML, avoiding the Rails safe-YAML loader silently dropping `changeset` when it
+  # contains ActiveSupport::TimeWithZone (e.g. the always-present updated_at).
+  def change
+    add_column :versions, :object_changes, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_13_153908) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_160019) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -342,6 +342,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_153908) do
     t.string "item_type", null: false
     t.string "event", null: false
     t.text "object"
+    t.jsonb "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/spec/features/patient_state_spec.rb
+++ b/spec/features/patient_state_spec.rb
@@ -6,21 +6,31 @@ RSpec.feature 'Patient state transitions', type: :feature, js: true do
   before { login_as admin, scope: :user }
 
   scenario 'an admin advances a prospect patient to candidate from the patients list' do
-    create(:patient) # starts in the prospect state
+    patient = create(:patient) # starts in the prospect state
 
     visit patients_path
 
-    # A prospect patient exposes the "Evaluar" (assess) transition to an admin.
-    expect(page).to have_button('Evaluar')
-
-    click_button 'Evaluar'
+    # Scope every assertion to THIS patient's row (dom_id) rather than the whole
+    # page. Under transactional fixtures a real-browser (Selenium) spec runs the
+    # app server on a separate thread sharing the test connection, and can
+    # occasionally see an adjacent example's not-yet-rolled-back patient — which
+    # made a page-wide `have_button('Evaluar')` an ambiguous match. Row-scoping
+    # makes the spec hermetic regardless of stray rows.
+    within "#patient_#{patient.id}" do
+      # A prospect patient exposes the "Evaluar" (assess) transition to an admin.
+      expect(page).to have_button('Evaluar')
+      click_button 'Evaluar'
+    end
 
     # After assess: prospect -> candidate. Assert on what the user sees (feature
-    # specs shouldn't reach into the DB across the server thread): the assess
-    # button is gone, the candidate-state actions appear, and the flash confirms.
+    # specs shouldn't reach into the DB across the server thread): the flash
+    # confirms, and within the row the assess button is gone and the
+    # candidate-state actions appear.
     expect(page).to have_content('Estado actualizado correctamente.')
-    expect(page).to have_no_button('Evaluar')
-    expect(page).to have_button('Aceptar')
-    expect(page).to have_button('Descartar')
+    within "#patient_#{patient.id}" do
+      expect(page).to have_no_button('Evaluar')
+      expect(page).to have_button('Aceptar')
+      expect(page).to have_button('Descartar')
+    end
   end
 end

--- a/spec/models/paper_trail_audit_spec.rb
+++ b/spec/models/paper_trail_audit_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe "PaperTrail audit trail on patient-related models", type: :model 
 
   it "versions a Study (status/phase changes affect eligibility)" do
     study = FactoryBot.create(:study)
-    expect { study.update!(study_status: "completed") }
+    # Flip to a definitely-different status (the factory randomises it).
+    new_status = study.recruiting? ? "completed" : "recruiting"
+    expect { study.update!(study_status: new_status) }
       .to change { study.versions.count }.by(1)
   end
 end

--- a/spec/requests/change_controls_spec.rb
+++ b/spec/requests/change_controls_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe "Change control (audit log)", type: :request do
+  let(:patient) { FactoryBot.create(:patient) }
+
+  def change_control_for(item, **params)
+    change_control_path(item.class.name, item.id, **params)
+  end
+
+  context "as an admin" do
+    let(:admin_user) { FactoryBot.create(:user, :admin) }
+    before { sign_in(admin_user, scope: :user) }
+
+    def make_change!(attrs)
+      PaperTrail.request(whodunnit: admin_user.id.to_s) { patient.update!(attrs) }
+    end
+
+    it "renders the change log with a field-level diff attributed to the user" do
+      make_change!(notes: "seen in clinic")
+
+      get change_control_for(patient)
+
+      expect(response).to be_successful
+      expect(response.body).to include("Control de cambios")
+      expect(response.body).to include("Notes") # humanized attribute name
+      expect(response.body).to include("seen in clinic")
+      expect(response.body).to include(admin_user.fullname.presence || admin_user.email)
+    end
+
+    it "filters by event type" do
+      make_change!(notes: "first")
+
+      # Only 'update' events exist; filtering to 'destroy' yields nothing.
+      get change_control_for(patient, event: "destroy")
+      expect(response.body).to include("No hay cambios que coincidan")
+
+      get change_control_for(patient, event: "update")
+      expect(response.body).to include("first")
+    end
+
+    it "exports the change log as CSV" do
+      make_change!(notes: "csv row")
+
+      get change_control_for(patient, format: :csv)
+
+      expect(response).to be_successful
+      expect(response.content_type).to include("text/csv")
+      expect(response.body).to include("fecha,evento,usuario,campo,antes,despues")
+      expect(response.body).to include("csv row")
+    end
+
+    it "404s for an untracked / unknown type" do
+      get change_control_path("Sponsor", 1)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "as a non-admin (patient)" do
+    before { sign_in(FactoryBot.create(:user, :patient), scope: :user) }
+
+    it "is blocked" do
+      get change_control_for(patient)
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  context "when signed out" do
+    it "redirects to sign in" do
+      get change_control_for(patient)
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/views/criteria_variables/show.html.erb_spec.rb
+++ b/spec/views/criteria_variables/show.html.erb_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe "criteria_variables/show", type: :view do
 
     assign(:criteria_profile, profile)
     assign(:criteria_variable, variable)
+    # The view has an admin-only "Control de cambios" link gated on current_user,
+    # which isn't wired up in view specs (no Warden middleware).
+    allow(view).to receive(:current_user).and_return(nil)
 
     render template: 'criteria_variables/show'
 


### PR DESCRIPTION
## Summary

Adds an **admin-only Change Control** screen (read-only audit log) over every PaperTrail-tracked model, with filters, field-level diffs, and CSV export.

> Stacked on #42 (audit trail + attribution). Review/merge that first; this PR's diff is only the change-control work.

## What's included
- `ChangeControlsController` (+ `ChangeControlPolicy`, admin-only), route `GET /change-control/:item_type/:item_id`, model whitelist keyed by param.
- Filters by event / acting user / date range; CSV export; before→after field diffs (timestamps stripped).
- Store `versions.object_changes` as **jsonb** so PaperTrail's `changeset` works (the text/YAML path silently returned `{}` because Rails' safe loader can't deserialize `TimeWithZone` in `updated_at`).
- Admin-only "Control de cambios" links on patient/study/criteria-profile/criteria-variable show pages.
- Hardened the flaky `patient_state` js-feature spec (row-scoped) — a pre-existing transactional-fixtures + Selenium race, not this feature.

## Testing
Full suite green (174 examples, 0 failures at branch tip). RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)