### PR TITLE
Patient pseudonymization + Ley 1581/Art. 26 consent capture (tasks 3, 5, 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,15 +199,17 @@ Checked the requirements above against the current medici_app codebase directly 
 
 ### Critical pending tasks — compliance remediation (planned 2026-07-11)
 
-Each item below is a task to execute, not just a gem to install — most gaps need real development work, with a gem (if any) as only one ingredient. Ordered by priority. **Status as of 2026-07-11: 0/8 done — nothing has been remediated yet.** Check items off as they're completed, with a one-line dated note.
+Each item below is a task to execute, not just a gem to install — most gaps need real development work, with a gem (if any) as only one ingredient. Ordered by priority. **Status as of 2026-07-13: 3/8 done (tasks 1, 2, 6).** Check items off as they're completed, with a one-line dated note.
 
-- [ ] 1. **[CRITICAL — live exposure] Fix the Pundit access-control gap in `PatientsController`.**
+- [x] 1. **[CRITICAL — live exposure] Fix the Pundit access-control gap in `PatientsController`.** _(2026-07-13 — PR #28, role permissions.)_
    - Gem: none new — `pundit` is already in the Gemfile. This is a wiring task.
    - Dev work: extend `PatientPolicy` with real `index?`/`show?`/`update?` rules (not just the existing `update_state?`/AASM-transition methods, scoped by role); call `authorize`/`policy_scope` in `PatientsController#index`, `#show`, `#edit`, `#create`, and non-state `#update`. This is the highest-priority fix — it's a live exposure of every patient's `dob`/`sex`/`illness_description`/`notes` to any logged-in user today, not a future deadline risk.
+   - **Done:** `PatientsController < SecureApplicationController`, whose `ResourceAuthorization` concern auto-authorizes every standard action and whose `verify_authorized` after_action makes a missed `authorize` a failing spec (deny-by-default). The unscoped `index`/`show` exposure is closed.
 
-- [ ] 2. **[HIGH] Fix or remove the dead `StudyPolicy`.**
+- [x] 2. **[HIGH] Fix or remove the dead `StudyPolicy`.** _(2026-07-13 — PR #28, role permissions.)_
    - Gem: none new — `pundit` already present.
    - Dev work: either wire `authorize`/`policy_scope` into `StudiesController` so `StudyPolicy` actually runs, or remove it if intentionally unused — a policy file that looks like it's enforcing access but isn't is worse than no policy at all.
+   - **Done:** `StudiesController < SecureApplicationController` now authorizes (standard actions via `ResourceAuthorization`, plus an explicit `authorize(@study, :update?)` for its custom action); `StudyPolicy < ApplicationPolicy` inherits the real permission-driven rules — no longer dead code.
 
 - [ ] 3. **[CRITICAL] Implement Ley 1581 authorization capture at registration.**
    - Gem: none — no standard gem exists for Colombian habeas-data consent capture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Checked the requirements above against the current medici_app codebase directly 
 
 ### Critical pending tasks — compliance remediation (planned 2026-07-11)
 
-Each item below is a task to execute, not just a gem to install — most gaps need real development work, with a gem (if any) as only one ingredient. Ordered by priority. **Status as of 2026-07-13: 4/8 done (tasks 1, 2, 5, 6).** Check items off as they're completed, with a one-line dated note.
+Each item below is a task to execute, not just a gem to install — most gaps need real development work, with a gem (if any) as only one ingredient. Ordered by priority. **Status as of 2026-07-13: 6/8 done (tasks 1, 2, 3, 5, 6, 7).** Remaining: 4 (INVIMA multi-party consent — dev, blocked on legal task 8) and 8 (legal, not dev). Check items off as they're completed, with a one-line dated note.
 
 - [x] 1. **[CRITICAL — live exposure] Fix the Pundit access-control gap in `PatientsController`.** _(2026-07-13 — PR #28, role permissions.)_
    - Gem: none new — `pundit` is already in the Gemfile. This is a wiring task.
@@ -211,9 +211,10 @@ Each item below is a task to execute, not just a gem to install — most gaps ne
    - Dev work: either wire `authorize`/`policy_scope` into `StudiesController` so `StudyPolicy` actually runs, or remove it if intentionally unused — a policy file that looks like it's enforcing access but isn't is worse than no policy at all.
    - **Done:** `StudiesController < SecureApplicationController` now authorizes (standard actions via `ResourceAuthorization`, plus an explicit `authorize(@study, :update?)` for its custom action); `StudyPolicy < ApplicationPolicy` inherits the real permission-driven rules — no longer dead code.
 
-- [ ] 3. **[CRITICAL] Implement Ley 1581 authorization capture at registration.**
+- [x] 3. **[CRITICAL] Implement Ley 1581 authorization capture at registration.** _(2026-07-13 — branch `MA-pseudonymization`.)_
    - Gem: none — no standard gem exists for Colombian habeas-data consent capture.
    - Dev work: add a `Consent`/`Authorization` model (who authorized, what text/version, when) and a discrete, auditable step in the sign-up flow (`Users::RegistrationsController`) that captures it **before** `dob`/`sex`/`illness_description`/etc. start being collected — not folded into a generic terms-of-service checkbox.
+   - **Done:** `Consent` model (immutable, versioned: document_type/version, purpose, granted_at, ip_address; `has_paper_trail`). A distinct habeas-data authorization checkbox on the study-scoped sign-up form; registration is a hard gate (no account/data without it — rejected sign-up 422s and creates nothing); a `Consent` is persisted on success. Version bumps via `Consent::LEY_1581_CURRENT_VERSION`. Also fixed a latent "Userable must exist" registration bug (Patient is now built before the User is saved).
 
 - [ ] 4. **[CRITICAL] Implement INVIMA multi-party informed consent (participant + 2 witnesses + investigating physician).**
    - Gem options: `prawn` (add to Gemfile) to generate the consent PDF, + Active Storage (already in Rails, no separate gem) to attach the signed document; `hexapdf` (evaluate, don't add yet) if a digital-signature path is chosen instead of scanned wet-ink signatures.
@@ -230,9 +231,10 @@ Each item below is a task to execute, not just a gem to install — most gaps ne
    - Dev work: declare `has_paper_trail` on `Patient`, `CriteriaVariable`, `Study`, and any other model holding clinical/eligibility data.
    - **Done:** installed PaperTrail (`versions` table), wired `set_paper_trail_whodunnit` in `ApplicationController` (PaperTrail 15 no longer auto-installs it) so every change records the acting user, and declared `has_paper_trail` on `Patient`, `VariableValue`, `CriteriaVariable`, `CriteriaProfile`, and `Study`. Also added an `entered_by` user FK on `VariableValue` (first-capture attribution).
 
-- [ ] 7. **[MEDIUM] Add a cross-border transfer safeguard for international `Sponsor`s.**
+- [x] 7. **[MEDIUM] Add a cross-border transfer safeguard for international `Sponsor`s.** _(2026-07-13 — branch `MA-pseudonymization`.)_
    - Gem: none — this is a process/legal control (data transfer agreements, explicit consent language), not a technical one.
    - Dev work: minimal — mostly ensure the Ley 1581 authorization captured in task 3 explicitly covers transfer to a foreign sponsor when applicable, and flag/log which `Sponsor`s are international.
+   - **Done:** `sponsors.international` flag + `Study#international_sponsor?`. When enrolling in an international-sponsor study, the sign-up authorization shows an Art. 26 cross-border clause and a distinct `Consent` (`ley_1581_cross_border_transfer`) is recorded alongside the base one.
 
 - [ ] 8. **[MEDIUM — legal, not dev] Resolve the open INVIMA / Ley 1581 interaction questions.**
    - Not a development task: get legal confirmation on (a) whether INVIMA consent satisfies or stacks on top of Ley 1581 authorization, (b) electronic consent validity, (c) sponsor/DMC access rules to identifiable data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Checked the requirements above against the current medici_app codebase directly 
 
 ### Critical pending tasks — compliance remediation (planned 2026-07-11)
 
-Each item below is a task to execute, not just a gem to install — most gaps need real development work, with a gem (if any) as only one ingredient. Ordered by priority. **Status as of 2026-07-13: 3/8 done (tasks 1, 2, 6).** Check items off as they're completed, with a one-line dated note.
+Each item below is a task to execute, not just a gem to install — most gaps need real development work, with a gem (if any) as only one ingredient. Ordered by priority. **Status as of 2026-07-13: 4/8 done (tasks 1, 2, 5, 6).** Check items off as they're completed, with a one-line dated note.
 
 - [x] 1. **[CRITICAL — live exposure] Fix the Pundit access-control gap in `PatientsController`.** _(2026-07-13 — PR #28, role permissions.)_
    - Gem: none new — `pundit` is already in the Gemfile. This is a wiring task.
@@ -220,9 +220,10 @@ Each item below is a task to execute, not just a gem to install — most gaps ne
    - Dev work: build the consent capture flow (participant/legal representative + 2 witnesses + investigating physician), require re-signature when the form is amended, and track it as an auditable checklist item equivalent to INVIMA's item 32.
    - **Blocked on:** legal confirmation of whether a pure digital signature satisfies Resolución 2378 de 2008, or whether a scanned wet-ink signature is required — don't commit to the `hexapdf` path before this is confirmed.
 
-- [ ] 5. **[HIGH] Implement participant data pseudonymization/coding (Anexo Técnico Tabla 7).**
+- [x] 5. **[HIGH] Implement participant data pseudonymization/coding (Anexo Técnico Tabla 7).** _(2026-07-13 — branch `MA-pseudonymization`.)_
    - Gem: none new — use Rails 8's native `ActiveRecord::Encryption`.
    - Dev work: encrypt identifiable clinical fields (`illness_description`, `dob`, etc.) that feed into study/eligibility data, and add a participant-code column (`SecureRandom`-backed) so research data can be linked to identity only via that code, per the secure-storage requirement.
+   - **Done:** `Patient` now owns its identity (delegation moved off the shared `User` into `DelegatesIdentityToUser`, used only by Admin/reps) and encrypts `firstname`/`lastname`/`email`/`dob`/`contact_number`/`contact_address`/`id_number` (deterministic, searchable) + `illness_description`/`notes` (non-deterministic). `dob` moved date→string (+ `attribute :dob, :date`). Added `participant_code` (unique, `SecureRandom`, backfilled). `has_paper_trail skip:` the encrypted fields so plaintext never reaches the `versions` table. Keys via `config/initializers/active_record_encryption.rb` (ENV in prod). **Post-deploy:** set `AR_ENCRYPTION_*` env vars on Heroku, then run `rails patients:reencrypt` to encrypt existing rows. Devise login (`User#email`) is untouched. Status: 4/8 done (1, 2, 5, 6).
 
 - [x] 6. **[HIGH] Wire the audit trail.** _(2026-07-13 — branch `MA-variable-value-attribution`.)_
    - Gem: none new — `paper_trail` is already in the Gemfile.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,25 @@ Checked the requirements above against the current medici_app codebase directly 
 
 **Priority for remediation:** the `PatientsController` access-control gap is the most urgent — it's a live, exploitable exposure of sensitive health data to any logged-in user, not just a future compliance-deadline risk like the interoperability question.
 
+### Offshore hosting (Heroku/AWS) & "sponsors are just records" (researched 2026-07-13, web-sourced)
+
+**Question raised:** medici_app is deployed on Heroku, which runs on AWS with servers in the US, so *all* patient data physically lives outside Colombia. Does that mean every patient must give an international-transfer authorization? (Adversarially checked against Colombian secondary legal sources; this is informational, **not legal advice** — the clinical-trials/INVIMA layer may be stricter, and the SIC adequacy list can change.)
+
+**Finding — the key distinction is *transmisión* vs *transferencia* (Decreto 1377 de 2013, Art. 24–26):**
+- **Transferencia** = sending data to another **responsable** (controller) that processes it for **its own** purposes → gated by Ley 1581 **Art. 26**: allowed only to an adequate-protection country **or** with explicit consent (or another exception).
+- **Transmisión** = sending data to an **encargado** (processor) that processes **on the controller's behalf, under its instructions** → **does NOT require the titular's consent** when a data-processing/transmission **contract** exists (Art. 25). Foreign cloud hosting (Heroku/AWS) is a **transmisión**.
+- **So offshore hosting does NOT require a per-patient transfer opt-in.** What it requires is: (a) a **Data Processing / International Transmission Agreement (DPA)** with the provider (Salesforce/Heroku, AWS — both publish standard DPAs), and (b) the general Ley 1581 authorization to **acknowledge** that data may be processed by operators possibly located abroad. Security baseline: SIC recommends ISO/IEC 27001.
+- **Bonus:** the **US is on the SIC's adequate-protection list** (Circular Externa 005 de 2017, ~37 jurisdictions — controversially, but it is listed), so even a US *transferencia* would satisfy Art. 26's adequacy exception.
+
+**Domain correction (2026-07-13):** in medici_app, **`Sponsor` records are just labels to organize studies — the app does not actually transmit patient data to sponsors.** The only legally-bound data subject is the **`Patient`**. Therefore the "transferencia to a foreign sponsor" scenario (task 7's original premise) is **not a real data flow here**; the real offshore flow is the **hosting transmisión**, which every patient's data is subject to. The `sponsors.international` flag + sponsor cross-border consent built for task 7 are harmless but **precautionary, not a legally-triggered requirement** given sponsors aren't recipients.
+
+**What medici_app actually needs (net of the above):**
+1. **[dev — done 2026-07-13]** The base Ley 1581 authorization text acknowledges processing by third-party operators possibly abroad under a transmission contract (added to the sign-up consent).
+2. **[legal/process — not code]** Execute DPAs with Heroku/Salesforce and AWS; confirm ISO 27001 posture. Confirm who is "responsable" (likely the trial site/sponsor entity, not the software vendor).
+3. The sponsor cross-border-consent code stays as a dormant safeguard; do **not** treat it as the mechanism that legitimizes offshore hosting — that's the DPA + base-consent acknowledgment.
+
+Sources: [Ley 1581 de 2012](https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=49981), [Decreto 1377 de 2013](https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=53646), [Ámbito Jurídico – régimen de transferencias](https://www.ambitojuridico.com/noticias/comercial/regimen-de-transferencias-internacionales-de-datos-personales-una-guia-rapida), [Cuadro Legal – nube (2025)](https://cuadrolegal.com/2025/11/05/habeas-data-y-servicios-de-computacion-en-la-nube/), [SIC Circular Externa 005 de 2017](https://normograma.dian.gov.co/dian/compilacion/docs/circular_superindustria_0005_2017.htm).
+
 ### Critical pending tasks — compliance remediation (planned 2026-07-11)
 
 Each item below is a task to execute, not just a gem to install — most gaps need real development work, with a gem (if any) as only one ingredient. Ordered by priority. **Status as of 2026-07-13: 6/8 done (tasks 1, 2, 3, 5, 6, 7).** Remaining: 4 (INVIMA multi-party consent — dev, blocked on legal task 8) and 8 (legal, not dev). Check items off as they're completed, with a one-line dated note.
@@ -235,7 +254,9 @@ Each item below is a task to execute, not just a gem to install — most gaps ne
    - Gem: none — this is a process/legal control (data transfer agreements, explicit consent language), not a technical one.
    - Dev work: minimal — mostly ensure the Ley 1581 authorization captured in task 3 explicitly covers transfer to a foreign sponsor when applicable, and flag/log which `Sponsor`s are international.
    - **Done:** `sponsors.international` flag + `Study#international_sponsor?`. When enrolling in an international-sponsor study, the sign-up authorization shows an Art. 26 cross-border clause and a distinct `Consent` (`ley_1581_cross_border_transfer`) is recorded alongside the base one.
+   - **Re-fit (2026-07-13, see "Offshore hosting" note above):** the real offshore data flow is **hosting on Heroku/AWS (US), which is a *transmisión* to a processor**, not a transferencia — handled by a **DPA (legal/process)** + a *transmisión* acknowledgment now in the **base** consent text (all patients), not by a per-patient opt-in. And **`Sponsor`s are only records** (no real data flow to them), so this sponsor cross-border consent is **precautionary, not legally triggered**. Remaining real item is **legal/process**: execute DPAs with Heroku/Salesforce + AWS and confirm the "responsable" is the trial site/sponsor entity.
 
 - [ ] 8. **[MEDIUM — legal, not dev] Resolve the open INVIMA / Ley 1581 interaction questions.**
    - Not a development task: get legal confirmation on (a) whether INVIMA consent satisfies or stacks on top of Ley 1581 authorization, (b) electronic consent validity, (c) sponsor/DMC access rules to identifiable data.
    - Blocks the final design of tasks 3 and 4 — build the safer "both required" version now, revise once confirmed.
+   - **Cross-border question RESOLVED (2026-07-13):** offshore hosting = *transmisión* (DPA, not per-patient consent); US is on the SIC adequacy list. Remaining legal items are the INVIMA consent questions (a/b/c above) + executing the hosting DPAs (a contract/process task, not code). See the "Offshore hosting" research note above.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :study_id ])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :study_id, :data_processing_authorization ])
   end
 
   private

--- a/app/controllers/change_controls_controller.rb
+++ b/app/controllers/change_controls_controller.rb
@@ -1,0 +1,85 @@
+require "csv"
+
+class ChangeControlsController < SecureApplicationController
+  # Whitelist of audited models exposed through the change-control view, keyed by
+  # the param value so an arbitrary class name can never be constantized from input.
+  TRACKED_MODELS = {
+    "Patient" => Patient,
+    "Study" => Study,
+    "CriteriaProfile" => CriteriaProfile,
+    "CriteriaVariable" => CriteriaVariable,
+    "VariableValue" => VariableValue
+  }.freeze
+
+  def show
+    @item = find_item
+    authorize @item, :show?, policy_class: ChangeControlPolicy
+
+    # Editors are drawn from ALL versions (not the filtered set) so the user filter
+    # always lists everyone who ever touched the record.
+    @editors = editors_for(@item)
+    @versions = filtered_versions
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        send_data change_control_csv(@versions, @editors),
+                  filename: "change-control-#{params[:item_type].underscore}-#{@item.id}.csv"
+      end
+    end
+  end
+
+  private
+
+  def find_item
+    klass = TRACKED_MODELS[params[:item_type]]
+    raise ActiveRecord::RecordNotFound, "Untracked type" unless klass
+
+    klass.find(params[:item_id])
+  end
+
+  # Apply the optional filters: event type, acting user (whodunnit), and date range.
+  def filtered_versions
+    scope = @item.versions.reorder(created_at: :desc, id: :desc)
+    scope = scope.where(event: params[:event]) if params[:event].present?
+    scope = scope.where(whodunnit: params[:whodunnit]) if params[:whodunnit].present?
+    if (from = parse_date(params[:from]))
+      scope = scope.where(created_at: from.beginning_of_day..)
+    end
+    if (to = parse_date(params[:to]))
+      scope = scope.where(created_at: ..to.end_of_day)
+    end
+    scope
+  end
+
+  def editors_for(item)
+    ids = item.versions.reorder(nil).distinct.pluck(:whodunnit).compact
+    User.where(id: ids).index_by { |u| u.id.to_s }
+  end
+
+  def parse_date(str)
+    return nil if str.blank?
+
+    Date.parse(str)
+  rescue ArgumentError
+    nil
+  end
+
+  def change_control_csv(versions, editors)
+    CSV.generate(headers: true) do |csv|
+      csv << %w[fecha evento usuario campo antes despues]
+      versions.each do |version|
+        editor = editors[version.whodunnit]
+        who = editor ? (editor.fullname.presence || editor.email) : version.whodunnit
+        changes = helpers.change_control_diff(version)
+        if changes.empty?
+          csv << [ version.created_at, version.event, who, nil, nil, nil ]
+        else
+          changes.each do |attr, (old_val, new_val)|
+            csv << [ version.created_at, version.event, who, attr, old_val, new_val ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,12 +11,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
       if session[:study_id].present?
         study = Study.find_by(id: session[:study_id])
         if study
-          new_patient = Patient.create!
+          # Patient owns its identity now; seed its (encrypted) email from the
+          # sign-up email so the record isn't identity-less. Devise login still
+          # authenticates against User#email.
+          new_patient = Patient.create!(email: resource.email)
           resource.userable = new_patient
           study.users << resource
           # Ensure the user has a Patient profile via delegated_type
           unless resource.patient?
-            patient_profile = Patient.create!
+            patient_profile = Patient.create!(email: resource.email)
             resource.update(userable: patient_profile)
           end
           # Aquí puedes asociar el study al nuevo usuario

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -32,6 +32,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @study.users << resource if @study
       # Persist the habeas-data authorization as an immutable, auditable record.
       Consent.record_ley_1581!(resource, ip_address: request.remote_ip)
+      # If the study's sponsor is a foreign entity, the same authorization also
+      # covers the cross-border transfer (Ley 1581 Art. 26) — record it distinctly.
+      if @study&.international_sponsor?
+        Consent.record_cross_border_transfer!(resource, ip_address: request.remote_ip)
+      end
       session.delete(:study_id)
 
       sign_up(resource_name, resource)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,31 +3,49 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   def new
     session[:study_id] = params[:study_id] if params[:study_id].present?
+    @study = Study.find_by(id: session[:study_id])
     super
   end
 
   def create
-    super do |resource|
-      if session[:study_id].present?
-        study = Study.find_by(id: session[:study_id])
-        if study
-          # Patient owns its identity now; seed its (encrypted) email from the
-          # sign-up email so the record isn't identity-less. Devise login still
-          # authenticates against User#email.
-          new_patient = Patient.create!(email: resource.email)
-          resource.userable = new_patient
-          study.users << resource
-          # Ensure the user has a Patient profile via delegated_type
-          unless resource.patient?
-            patient_profile = Patient.create!(email: resource.email)
-            resource.update(userable: patient_profile)
-          end
-          # Aquí puedes asociar el study al nuevo usuario
-          # study.update(user: resource)
-        end
-        session.delete(:study_id)
-      end
+    @study = Study.find_by(id: session[:study_id])
+
+    # Ley 1581 de 2012 (Art. 6, 9): explicit, prior authorization to process
+    # sensitive health data is a hard gate — no account is created (and therefore
+    # no patient data is collected) until it is granted.
+    unless data_processing_authorized?
+      build_resource(sign_up_params)
+      resource.errors.add(:data_processing_authorization,
+                          "Debe autorizar el tratamiento de datos personales sensibles para registrarse.")
+      clean_up_passwords(resource)
+      render :new, status: :unprocessable_entity
+      return
     end
+
+    build_resource(sign_up_params)
+    # Patient owns its identity; build it up-front so the required `userable`
+    # (delegated_type) exists at save time. Seed its (encrypted) email from the
+    # sign-up email — Devise login still authenticates against User#email.
+    resource.userable = Patient.new(email: resource.email)
+
+    if resource.save
+      @study.users << resource if @study
+      # Persist the habeas-data authorization as an immutable, auditable record.
+      Consent.record_ley_1581!(resource, ip_address: request.remote_ip)
+      session.delete(:study_id)
+
+      sign_up(resource_name, resource)
+      respond_with resource, location: after_sign_up_path_for(resource)
+    else
+      clean_up_passwords(resource)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def data_processing_authorized?
+    ActiveModel::Type::Boolean.new.cast(params.dig(:user, :data_processing_authorization))
   end
 
   # before_action :configure_sign_up_params, only: [:create]

--- a/app/helpers/change_controls_helper.rb
+++ b/app/helpers/change_controls_helper.rb
@@ -1,0 +1,37 @@
+module ChangeControlsHelper
+  # Attributes not worth showing in a change diff (always-present, low-signal).
+  IGNORED_CHANGE_KEYS = %w[updated_at created_at].freeze
+
+  # The meaningful field-level changes for a version, as { attr => [old, new] },
+  # with noise (timestamps) stripped. Returns {} when nothing survives.
+  def change_control_diff(version)
+    (version.changeset || {}).except(*IGNORED_CHANGE_KEYS)
+  end
+
+  # Render one side of a diff for display: nil as an em-dash, arrays joined,
+  # everything else as a plain string.
+  def change_control_value(value)
+    return content_tag(:span, "∅", class: "text-muted") if value.nil?
+    return content_tag(:span, "(vacío)", class: "text-muted") if value.respond_to?(:empty?) && value.empty?
+
+    display = value.is_a?(Array) ? value.join(", ") : value.to_s
+    truncate(display, length: 120)
+  end
+
+  # Bootstrap badge colour for a PaperTrail event.
+  def change_control_event_badge(event)
+    { "create" => "success", "update" => "primary", "destroy" => "danger" }.fetch(event, "secondary")
+  end
+
+  # Human name for the acting user behind a version's whodunnit, using a
+  # preloaded { id_string => User } map.
+  def change_control_editor_name(version, editors)
+    if (editor = editors[version.whodunnit])
+      editor.fullname.presence || editor.email
+    elsif version.whodunnit.present?
+      content_tag(:span, "Usuario ##{version.whodunnit} (eliminado)", class: "text-muted")
+    else
+      content_tag(:span, "Sistema / sin sesión", class: "text-muted")
+    end
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -11,4 +11,5 @@
 #
 class Admin < ApplicationRecord
   include Userable
+  include DelegatesIdentityToUser
 end

--- a/app/models/concerns/delegates_identity_to_user.rb
+++ b/app/models/concerns/delegates_identity_to_user.rb
@@ -1,0 +1,12 @@
+# Identity (name/email) delegation for userable roles that DON'T store their own
+# identity — Admin, SponsorRep, TrialCenterBranchRep read it from the User.
+#
+# Patient deliberately does NOT include this: it owns encrypted identity columns
+# so participant data can be pseudonymized independently of the shared User row.
+module DelegatesIdentityToUser
+  extend ActiveSupport::Concern
+
+  included do
+    delegate :firstname, :lastname, :email, :fullname, to: :user, allow_nil: true
+  end
+end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -1,0 +1,56 @@
+# == Schema Information
+#
+# Table name: consents
+#
+#  id               :bigint           not null, primary key
+#  document_type    :string           not null
+#  document_version :string           not null
+#  granted_at       :datetime         not null
+#  ip_address       :string
+#  purpose          :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  user_id          :bigint           not null
+#
+# Indexes
+#
+#  index_consents_on_user_id                    (user_id)
+#  index_consents_on_user_id_and_document_type  (user_id,document_type)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+# An immutable record that a user granted a specific, versioned authorization —
+# the Ley 1581 de 2012 habeas-data authorization to process sensitive health data,
+# captured as a discrete, auditable step at registration (not folded into a
+# generic terms-of-service acceptance).
+class Consent < ApplicationRecord
+  # Document types.
+  LEY_1581_HABEAS_DATA = "ley_1581_habeas_data".freeze
+
+  # Bump when the authorization text changes; the accepted version is stored per
+  # record so we always know exactly what a patient agreed to.
+  LEY_1581_CURRENT_VERSION = "2026-07-13".freeze
+
+  # Processing purposes.
+  PURPOSE_SENSITIVE_HEALTH = "sensitive_health_data_processing".freeze
+
+  has_paper_trail
+
+  belongs_to :user
+
+  validates :document_type, :document_version, :purpose, :granted_at, presence: true
+
+  # Record the Ley 1581 sensitive-health-data authorization for a user.
+  def self.record_ley_1581!(user, ip_address: nil)
+    create!(
+      user: user,
+      document_type: LEY_1581_HABEAS_DATA,
+      document_version: LEY_1581_CURRENT_VERSION,
+      purpose: PURPOSE_SENSITIVE_HEALTH,
+      granted_at: Time.current,
+      ip_address: ip_address
+    )
+  end
+end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -32,7 +32,8 @@ class Consent < ApplicationRecord
 
   # Bump when the authorization text changes; the accepted version is stored per
   # record so we always know exactly what a patient agreed to.
-  LEY_1581_CURRENT_VERSION = "2026-07-13".freeze
+  # 2026-07-13.1: added the "processors possibly abroad (transmisión)" acknowledgment.
+  LEY_1581_CURRENT_VERSION = "2026-07-13.1".freeze
 
   # Processing purposes.
   PURPOSE_SENSITIVE_HEALTH = "sensitive_health_data_processing".freeze

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -28,6 +28,7 @@
 class Consent < ApplicationRecord
   # Document types.
   LEY_1581_HABEAS_DATA = "ley_1581_habeas_data".freeze
+  LEY_1581_CROSS_BORDER = "ley_1581_cross_border_transfer".freeze
 
   # Bump when the authorization text changes; the accepted version is stored per
   # record so we always know exactly what a patient agreed to.
@@ -35,6 +36,7 @@ class Consent < ApplicationRecord
 
   # Processing purposes.
   PURPOSE_SENSITIVE_HEALTH = "sensitive_health_data_processing".freeze
+  PURPOSE_CROSS_BORDER_TRANSFER = "cross_border_transfer_to_foreign_sponsor".freeze
 
   has_paper_trail
 
@@ -49,6 +51,19 @@ class Consent < ApplicationRecord
       document_type: LEY_1581_HABEAS_DATA,
       document_version: LEY_1581_CURRENT_VERSION,
       purpose: PURPOSE_SENSITIVE_HEALTH,
+      granted_at: Time.current,
+      ip_address: ip_address
+    )
+  end
+
+  # Record the Ley 1581 Art. 26 authorization to transfer data to a foreign
+  # sponsor. Only applicable when the study's sponsor is international.
+  def self.record_cross_border_transfer!(user, ip_address: nil)
+    create!(
+      user: user,
+      document_type: LEY_1581_CROSS_BORDER,
+      document_version: LEY_1581_CURRENT_VERSION,
+      purpose: PURPOSE_CROSS_BORDER_TRANSFER,
       granted_at: Time.current,
       ip_address: ip_address
     )

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -6,7 +6,7 @@
 #  contact_address     :string
 #  contact_number      :string
 #  country             :string           default("")
-#  dob                 :date
+#  dob                 :string
 #  email               :string
 #  firstname           :string
 #  id_number           :string           default("")
@@ -14,6 +14,7 @@
 #  illness_description :text             default("")
 #  lastname            :string
 #  notes               :string
+#  participant_code    :string
 #  sex                 :string
 #  state               :string           default("prospect"), not null
 #  created_at          :datetime         not null
@@ -21,16 +22,45 @@
 #
 # Indexes
 #
-#  index_patients_on_state  (state)
+#  index_patients_on_participant_code  (participant_code) UNIQUE
+#  index_patients_on_state             (state)
 #
 class Patient < ApplicationRecord
   include Userable
 
-  # Audit trail for the patient's personal/clinical data and AASM state changes;
-  # whodunnit records the acting user (see PaperTrail controller integration).
-  has_paper_trail
+  # Pseudonymization (INVIMA Anexo Técnico Tabla 7): the patient owns its own
+  # identity/clinical columns (it does NOT delegate identity to the shared User —
+  # see DelegatesIdentityToUser), and those columns are encrypted at rest.
+  #
+  # Deterministic for the fields we search/look a patient up by (exact-match
+  # queries + unique-ish identifiers); non-deterministic (stronger) for free-text
+  # clinical data we never query by value. Patient#email is NOT the Devise login
+  # (that stays on User), so encrypting it here has no auth impact.
+  ENCRYPTED_DETERMINISTIC = %i[firstname lastname email dob contact_number contact_address id_number].freeze
+  ENCRYPTED_NON_DETERMINISTIC = %i[illness_description notes].freeze
+
+  # dob is stored as a string column (ciphertext can't live in a date column) but
+  # still behaves as a Date in Ruby.
+  attribute :dob, :date
+
+  encrypts(*ENCRYPTED_DETERMINISTIC, deterministic: true)
+  encrypts(*ENCRYPTED_NON_DETERMINISTIC)
+
+  # Audit trail for AASM state changes and non-sensitive attributes. Skip the
+  # encrypted fields so their plaintext is never copied into the versions table
+  # (which lives in the same database) — the audit log must not defeat encryption.
+  has_paper_trail skip: (ENCRYPTED_DETERMINISTIC + ENCRYPTED_NON_DETERMINISTIC)
 
   has_many :variable_values, dependent: :destroy
+
+  # A non-identifying code linking research/eligibility data back to the patient
+  # by code rather than identity.
+  before_create :assign_participant_code
+  validates :participant_code, uniqueness: true, allow_nil: true
+
+  def fullname
+    [ firstname, lastname ].compact_blank.join(" ")
+  end
 
   include AASM
 
@@ -53,6 +83,17 @@ class Patient < ApplicationRecord
 
     event :reject do
       transitions from: :participant, to: :candidate
+    end
+  end
+
+  private
+
+  def assign_participant_code
+    return if participant_code.present?
+
+    self.participant_code = loop do
+      candidate = "P-#{SecureRandom.alphanumeric(8).upcase}"
+      break candidate unless Patient.exists?(participant_code: candidate)
     end
   end
 end

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -2,13 +2,14 @@
 #
 # Table name: sponsors
 #
-#  id           :bigint           not null, primary key
-#  initials     :string
-#  name         :string
-#  shortname    :string
-#  sponsor_type :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id            :bigint           not null, primary key
+#  initials      :string
+#  international  :boolean          default(FALSE), not null
+#  name          :string
+#  shortname     :string
+#  sponsor_type  :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 class Sponsor < ApplicationRecord
   enum :sponsor_type, private_type: "private_type", public_type: "public_type", mixed_type: "mixed_type"

--- a/app/models/sponsor_rep.rb
+++ b/app/models/sponsor_rep.rb
@@ -20,6 +20,7 @@
 #
 class SponsorRep < ApplicationRecord
   include Userable
+  include DelegatesIdentityToUser
 
   belongs_to :sponsor
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -37,6 +37,12 @@ class Study < ApplicationRecord
 
   belongs_to :sponsor
 
+  # Whether enrolling in this study implies a cross-border transfer of patient
+  # data to a foreign sponsor (Ley 1581 Art. 26).
+  def international_sponsor?
+    !!sponsor&.international?
+  end
+
   has_and_belongs_to_many :trial_center_branches
   has_and_belongs_to_many :users
   has_and_belongs_to_many :medications

--- a/app/models/trial_center_branch_rep.rb
+++ b/app/models/trial_center_branch_rep.rb
@@ -20,6 +20,7 @@
 #
 class TrialCenterBranchRep < ApplicationRecord
   include Userable
+  include DelegatesIdentityToUser
 
   belongs_to :trial_center_branch
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,12 @@ class User < ApplicationRecord
 
   has_and_belongs_to_many :studies
   has_many :criteria_profiles, dependent: :destroy
+  has_many :consents, dependent: :destroy
   belongs_to :role, optional: true
+
+  # Virtual: the Ley 1581 habeas-data authorization checkbox on the sign-up form.
+  # Enforced (and persisted as a Consent) in Users::RegistrationsController.
+  attr_accessor :data_processing_authorization
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/models/userable.rb
+++ b/app/models/userable.rb
@@ -5,7 +5,5 @@ module Userable
     has_one :user, as: :userable, touch: true, dependent: :destroy
 
     accepts_nested_attributes_for :user
-
-    delegate :firstname, :lastname, :email, :fullname, to: :user, allow_nil: true
   end
 end

--- a/app/policies/change_control_policy.rb
+++ b/app/policies/change_control_policy.rb
@@ -1,0 +1,8 @@
+# Change-control (audit) view is admin-only *for now* — intentionally stricter
+# than the per-resource `can_show` permission that ApplicationPolicy grants. When
+# other roles should see the change log, widen this single method.
+class ChangeControlPolicy < ApplicationPolicy
+  def show?
+    !!user&.admin?
+  end
+end

--- a/app/views/change_controls/show.html.erb
+++ b/app/views/change_controls/show.html.erb
@@ -1,0 +1,87 @@
+<% item_label = "#{params[:item_type]} ##{@item.id}" %>
+<% content_for :title, "Control de cambios — #{item_label}" %>
+<% base_path = change_control_path(params[:item_type], @item.id) %>
+
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h3 class="mb-0">Control de cambios <small class="text-muted">— <%= item_label %></small></h3>
+    <div class="d-flex gap-2">
+      <%= link_to "Exportar CSV",
+                  change_control_path(params[:item_type], @item.id,
+                    format: :csv, event: params[:event], whodunnit: params[:whodunnit],
+                    from: params[:from], to: params[:to]),
+                  class: "btn btn-sm btn-outline-success" %>
+      <%= link_to "Volver", :back, class: "btn btn-sm btn-outline-secondary" %>
+    </div>
+  </div>
+
+  <%= form_with url: base_path, method: :get, class: "row g-2 align-items-end mb-3" do |f| %>
+    <div class="col-auto">
+      <%= label_tag :event, "Evento", class: "form-label mb-0 small" %>
+      <%= select_tag :event,
+            options_for_select([ [ "Todos", "" ], [ "Creación", "create" ], [ "Actualización", "update" ], [ "Eliminación", "destroy" ] ], params[:event]),
+            class: "form-select form-select-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= label_tag :whodunnit, "Usuario", class: "form-label mb-0 small" %>
+      <%= select_tag :whodunnit,
+            options_for_select([ [ "Todos", "" ] ] + @editors.values.map { |u| [ (u.fullname.presence || u.email), u.id.to_s ] }, params[:whodunnit]),
+            class: "form-select form-select-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= label_tag :from, "Desde", class: "form-label mb-0 small" %>
+      <%= date_field_tag :from, params[:from], class: "form-control form-control-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= label_tag :to, "Hasta", class: "form-label mb-0 small" %>
+      <%= date_field_tag :to, params[:to], class: "form-control form-control-sm" %>
+    </div>
+    <div class="col-auto">
+      <%= submit_tag "Filtrar", class: "btn btn-sm btn-primary" %>
+      <%= link_to "Limpiar", base_path, class: "btn btn-sm btn-outline-secondary" %>
+    </div>
+  <% end %>
+
+  <% if @versions.empty? %>
+    <div class="alert alert-info">No hay cambios que coincidan con los filtros.</div>
+  <% else %>
+    <div class="table-responsive">
+      <table class="table table-sm table-striped align-middle">
+        <thead>
+          <tr>
+            <th class="text-nowrap">Fecha</th>
+            <th>Evento</th>
+            <th>Usuario</th>
+            <th>Cambios</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @versions.each do |version| %>
+            <tr>
+              <td class="text-nowrap"><%= version.created_at&.strftime("%Y-%m-%d %H:%M") %></td>
+              <td><span class="badge bg-<%= change_control_event_badge(version.event) %>"><%= version.event %></span></td>
+              <td><%= change_control_editor_name(version, @editors) %></td>
+              <td>
+                <% diff = change_control_diff(version) %>
+                <% if diff.empty? %>
+                  <span class="text-muted">—</span>
+                <% else %>
+                  <ul class="mb-0 ps-3 small">
+                    <% diff.each do |attr, (old_val, new_val)| %>
+                      <li>
+                        <strong><%= attr.humanize %>:</strong>
+                        <%= change_control_value(old_val) %>
+                        &rarr;
+                        <%= change_control_value(new_val) %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/criteria_profiles/show.html.erb
+++ b/app/views/criteria_profiles/show.html.erb
@@ -8,6 +8,9 @@
       <div class="mt-3">
         <%= link_to "Editar", edit_criteria_profile_path(@criteria_profile) %> |
         <%= link_to "Retornar a Perfiles", criteria_profiles_path %>
+        <% if current_user&.admin? %>
+          | <%= link_to "Control de cambios", change_control_path("CriteriaProfile", @criteria_profile.id) %>
+        <% end %>
 
         <%= button_to "Borrar", @criteria_profile, method: :delete, class: "btn btn-primary btn-block mt-3 mb-3" %>
       </div>

--- a/app/views/criteria_variables/show.html.erb
+++ b/app/views/criteria_variables/show.html.erb
@@ -8,6 +8,9 @@
       <div class="mt-3">
         <%= link_to "Editar", edit_criteria_profile_criteria_variable_path(@criteria_profile, @criteria_variable) %> |
         <%= link_to "Retornar a Variables", criteria_profile_criteria_variables_path(@criteria_profile) %>
+        <% if current_user&.admin? %>
+          | <%= link_to "Control de cambios", change_control_path("CriteriaVariable", @criteria_variable.id) %>
+        <% end %>
 
         <%= button_to "Borrar", [@criteria_profile, @criteria_variable], method: :delete, class: "btn btn-primary btn-block mt-3 mb-3" %>
       </div>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -19,6 +19,9 @@
 <div>
   <%= link_to "Edit this patient", edit_patient_path(@patient) %> |
   <%= link_to "Back to patients", patients_path %>
+  <% if current_user&.admin? %>
+    | <%= link_to "Control de cambios", change_control_path("Patient", @patient.id) %>
+  <% end %>
 
   <%= button_to "Destroy this patient", @patient, method: :delete %>
 </div>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -5,6 +5,9 @@
       <div>
         <%= link_to "Editar este estudio", edit_study_path(@study) %> |
         <%= link_to "Retornar a Estudios", studies_path %>
+        <% if current_user&.admin? %>
+          | <%= link_to "Control de cambios", change_control_path("Study", @study.id) %>
+        <% end %>
 
         <%= button_to "Borrar", @study, method: :delete, class: "btn btn-primary btn-block mt-3 mb-3" %>
       </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,15 +4,16 @@
   <div class="row">
     <div class="col-3 mx-auto">
       <h1>Bienvenido al estudio:</h1>
-      <div class="card mb-3">
-        <div class="card-header">
-          <%= Study.find(params[:study_id]).public_title %>
+      <% if @study %>
+        <div class="card mb-3">
+          <div class="card-header">
+            <%= @study.public_title %>
+          </div>
+          <div class="card-body">
+            <%= @study.scientific_title %>
+          </div>
         </div>
-        <div class="card-body">
-          <%= Study.find(params[:study_id]).scientific_title %>
-
-        </div>
-      </div>
+      <% end %>
       <h2>Regístrate para poder participar</h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
@@ -34,6 +35,17 @@
         <div class="form-group mb-3">
           <%= f.label :password_confirmation %><br />
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+        </div>
+
+        <div class="form-check mt-4 mb-2 p-3 border rounded bg-light">
+          <%= f.check_box :data_processing_authorization, class: "form-check-input" %>
+          <%= f.label :data_processing_authorization, class: "form-check-label" do %>
+            Autorizo de manera libre, previa, expresa e informada el tratamiento de mis
+            <strong>datos personales sensibles de salud</strong> con la finalidad de evaluar mi
+            elegibilidad y participación en el estudio clínico, conforme a la
+            <strong>Ley 1581 de 2012</strong> (Habeas Data).
+            <span class="text-muted d-block small mt-1">Versión <%= Consent::LEY_1581_CURRENT_VERSION %></span>
+          <% end %>
         </div>
 
         <div class="actions">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -44,6 +44,9 @@
             <strong>datos personales sensibles de salud</strong> con la finalidad de evaluar mi
             elegibilidad y participación en el estudio clínico, conforme a la
             <strong>Ley 1581 de 2012</strong> (Habeas Data).
+            Entiendo que mis datos podrán ser almacenados y procesados por
+            <strong>operadores tecnológicos (encargados) que pueden estar ubicados fuera de Colombia</strong>,
+            bajo un contrato de transmisión que garantiza su seguridad y confidencialidad.
             <% if @study&.international_sponsor? %>
               Autorizo asimismo la <strong>transferencia de mis datos a un patrocinador
               internacional</strong> ubicado fuera de Colombia, conforme al Art. 26 de la Ley 1581 de 2012.

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -44,6 +44,10 @@
             <strong>datos personales sensibles de salud</strong> con la finalidad de evaluar mi
             elegibilidad y participación en el estudio clínico, conforme a la
             <strong>Ley 1581 de 2012</strong> (Habeas Data).
+            <% if @study&.international_sponsor? %>
+              Autorizo asimismo la <strong>transferencia de mis datos a un patrocinador
+              internacional</strong> ubicado fuera de Colombia, conforme al Art. 26 de la Ley 1581 de 2012.
+            <% end %>
             <span class="text-muted d-block small mt-1">Versión <%= Consent::LEY_1581_CURRENT_VERSION %></span>
           <% end %>
         </div>

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -1,0 +1,24 @@
+# ActiveRecord::Encryption keys (pseudonymization of identifiable patient data —
+# INVIMA Anexo Técnico Tabla 7). Production MUST supply real keys via ENV; a
+# missing key raises here rather than silently falling back to a weak default.
+# Generate a fresh set with `bin/rails db:encryption:init` and set on Heroku:
+#   heroku config:set AR_ENCRYPTION_PRIMARY_KEY=... AR_ENCRYPTION_DETERMINISTIC_KEY=... AR_ENCRYPTION_KEY_DERIVATION_SALT=...
+enc = Rails.application.config.active_record.encryption
+
+if Rails.env.production?
+  enc.primary_key         = ENV.fetch("AR_ENCRYPTION_PRIMARY_KEY")
+  enc.deterministic_key   = ENV.fetch("AR_ENCRYPTION_DETERMINISTIC_KEY")
+  enc.key_derivation_salt = ENV.fetch("AR_ENCRYPTION_KEY_DERIVATION_SALT")
+else
+  # Dev/test only — not secret, never used in production (guarded above).
+  enc.primary_key         = ENV.fetch("AR_ENCRYPTION_PRIMARY_KEY", "dev_only_primary_key_qHCBfSl6KxwHZGRZy5Tg")
+  enc.deterministic_key   = ENV.fetch("AR_ENCRYPTION_DETERMINISTIC_KEY", "dev_only_deterministic_FSaKBDMDLc6MrYzivbN9")
+  enc.key_derivation_salt = ENV.fetch("AR_ENCRYPTION_KEY_DERIVATION_SALT", "dev_only_salt_B2PfQhnVCq7so1LOnpctnZb9k8mW75Cq")
+end
+
+# Read rows written before encryption was enabled (existing dev/prod data), and
+# make deterministic queries match both encrypted and not-yet-encrypted values
+# during the transition. Re-encrypt existing rows post-deploy, then these can be
+# tightened. See lib/tasks/encryption.rake (patients:reencrypt).
+enc.support_unencrypted_data = true
+enc.extend_queries = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,9 @@ Rails.application.routes.draw do
   resources :criteria_profiles do
     resources :criteria_variables
   end
+
+  # Admin-only change-control (audit) log for any PaperTrail-tracked model.
+  get "change-control/:item_type/:item_id", to: "change_controls#show", as: :change_control
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260713160019_add_object_changes_to_versions.rb
+++ b/db/migrate/20260713160019_add_object_changes_to_versions.rb
@@ -1,0 +1,11 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration[8.0]
+  # PaperTrail populates this automatically when present, letting the change-control
+  # view show field-level diffs (what changed), not just who/when.
+  #
+  # jsonb (not text): PaperTrail then stores/reads the changeset as JSON instead of
+  # YAML, avoiding the Rails safe-YAML loader silently dropping `changeset` when it
+  # contains ActiveSupport::TimeWithZone (e.g. the always-present updated_at).
+  def change
+    add_column :versions, :object_changes, :jsonb
+  end
+end

--- a/db/migrate/20260713193026_add_participant_code_and_prepare_encryption.rb
+++ b/db/migrate/20260713193026_add_participant_code_and_prepare_encryption.rb
@@ -1,0 +1,61 @@
+class AddParticipantCodeAndPrepareEncryption < ActiveRecord::Migration[8.0]
+  # Pseudonymization groundwork (INVIMA Anexo Técnico Tabla 7):
+  #  - participant_code: a non-identifying code so research/eligibility data can be
+  #    linked back to a patient by code rather than by identity.
+  #  - dob date -> string: ActiveRecord::Encryption stores ciphertext (a string),
+  #    which a `date` column cannot hold. Other encrypted columns are already
+  #    unlimited `character varying`, which holds ciphertext fine.
+  def up
+    add_column :patients, :participant_code, :string
+    add_index :patients, :participant_code, unique: true
+
+    # date -> varchar needs an explicit cast in Postgres.
+    execute "ALTER TABLE patients ALTER COLUMN dob TYPE character varying USING dob::text"
+
+    backfill_participant_codes
+    backfill_patient_identity_from_user
+  end
+
+  def down
+    execute "ALTER TABLE patients ALTER COLUMN dob TYPE date USING dob::date"
+    remove_index :patients, :participant_code
+    remove_column :patients, :participant_code
+  end
+
+  private
+
+  # Raw SQL (not the Patient model) so encryption/paper_trail callbacks don't fire.
+  def backfill_participant_codes
+    say_with_time "Backfilling participant codes" do
+      used = select_values("SELECT participant_code FROM patients WHERE participant_code IS NOT NULL").to_set
+      ids = select_values("SELECT id FROM patients WHERE participant_code IS NULL")
+      ids.each do |id|
+        code = nil
+        loop do
+          code = "P-#{SecureRandom.alphanumeric(8).upcase}"
+          break unless used.include?(code)
+        end
+        used << code
+        execute("UPDATE patients SET participant_code = #{quote(code)} WHERE id = #{id.to_i}")
+      end
+      ids.size
+    end
+  end
+
+  # Patient now owns its identity (firstname/lastname/email) instead of delegating
+  # to User. Copy existing patients' identity from their User so names don't vanish
+  # for records created before this change. Raw SQL keeps it plaintext for now;
+  # `rails patients:reencrypt` (post-deploy) encrypts it at rest.
+  def backfill_patient_identity_from_user
+    say_with_time "Backfilling patient identity from user" do
+      execute(<<~SQL.squish)
+        UPDATE patients SET
+          firstname = COALESCE(NULLIF(patients.firstname, ''), u.firstname),
+          lastname  = COALESCE(NULLIF(patients.lastname, ''), u.lastname),
+          email     = COALESCE(NULLIF(patients.email, ''), u.email)
+        FROM users u
+        WHERE u.userable_type = 'Patient' AND u.userable_id = patients.id
+      SQL
+    end
+  end
+end

--- a/db/migrate/20260713202333_create_consents.rb
+++ b/db/migrate/20260713202333_create_consents.rb
@@ -1,0 +1,19 @@
+class CreateConsents < ActiveRecord::Migration[8.0]
+  # Ley 1581 de 2012 habeas-data authorization capture (Art. 6, 9): explicit,
+  # prior, informed authorization to process sensitive health data. One immutable
+  # record per authorization event, attributable to the user who granted it.
+  def change
+    create_table :consents do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :document_type, null: false   # e.g. "ley_1581_habeas_data"
+      t.string :document_version, null: false # which version of the text was accepted
+      t.string :purpose, null: false          # e.g. "sensitive_health_data_processing"
+      t.datetime :granted_at, null: false
+      t.string :ip_address                    # audit context of the acceptance
+
+      t.timestamps
+    end
+
+    add_index :consents, [ :user_id, :document_type ]
+  end
+end

--- a/db/migrate/20260713205844_add_international_to_sponsors.rb
+++ b/db/migrate/20260713205844_add_international_to_sponsors.rb
@@ -1,0 +1,7 @@
+class AddInternationalToSponsors < ActiveRecord::Migration[8.0]
+  # Flag sponsors that are foreign entities, so patient data flowing to them can
+  # be gated on an explicit Ley 1581 Art. 26 cross-border-transfer authorization.
+  def change
+    add_column :sponsors, :international, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_13_153908) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_160019) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -342,6 +342,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_153908) do
     t.string "item_type", null: false
     t.string "event", null: false
     t.text "object"
+    t.jsonb "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_13_193026) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_202333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -46,6 +46,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_193026) do
   create_table "cities_trial_center_facilities", id: false, force: :cascade do |t|
     t.bigint "city_id", null: false
     t.bigint "trial_center_facility_id", null: false
+  end
+
+  create_table "consents", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "document_type", null: false
+    t.string "document_version", null: false
+    t.string "purpose", null: false
+    t.datetime "granted_at", null: false
+    t.string "ip_address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "document_type"], name: "index_consents_on_user_id_and_document_type"
+    t.index ["user_id"], name: "index_consents_on_user_id"
   end
 
   create_table "contacts", force: :cascade do |t|
@@ -349,6 +362,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_193026) do
   end
 
   add_foreign_key "articles", "studies"
+  add_foreign_key "consents", "users"
   add_foreign_key "contacts", "studies"
   add_foreign_key "criteria_profiles", "studies"
   add_foreign_key "criteria_profiles", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_13_160019) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_193026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -142,7 +142,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_160019) do
   create_table "patients", force: :cascade do |t|
     t.string "firstname"
     t.string "lastname"
-    t.date "dob"
+    t.string "dob"
     t.string "sex"
     t.string "contact_number"
     t.string "contact_address"
@@ -155,6 +155,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_160019) do
     t.string "id_number", default: ""
     t.string "country", default: ""
     t.string "state", default: "prospect", null: false
+    t.string "participant_code"
+    t.index ["participant_code"], name: "index_patients_on_participant_code", unique: true
     t.index ["state"], name: "index_patients_on_state"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_13_202333) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_205844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -221,6 +221,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_202333) do
     t.string "sponsor_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "international", default: false, null: false
   end
 
   create_table "studies", force: :cascade do |t|

--- a/lib/tasks/encryption.rake
+++ b/lib/tasks/encryption.rake
@@ -1,0 +1,13 @@
+namespace :patients do
+  desc "Re-encrypt existing Patient rows at rest (run once after deploying pseudonymization)"
+  task reencrypt: :environment do
+    total = Patient.count
+    done = 0
+    Patient.find_each do |patient|
+      patient.encrypt
+      done += 1
+      puts "  re-encrypted #{done}/#{total}" if (done % 100).zero?
+    end
+    puts "Done: re-encrypted #{done}/#{total} patients."
+  end
+end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -25,6 +25,11 @@
 #
 FactoryBot.define do
   factory :patient do
+    # Patient owns its own (encrypted) identity now — set it here rather than on
+    # the User, so patient.firstname/fullname/email are populated in specs.
+    firstname { Faker::Name.first_name }
+    lastname { Faker::Name.last_name }
+    sequence(:email) { |n| "patient#{n}@example.com" }
     dob { Faker::Date.birthday(min_age: 18, max_age: 80) }
     sex { %w[male female].sample }
     # state defaults to "prospect" (DB default); AASM manages transitions.

--- a/spec/factories/sponsors.rb
+++ b/spec/factories/sponsors.rb
@@ -3,12 +3,13 @@
 # Table name: sponsors
 #
 #  id           :bigint           not null, primary key
-#  initials     :string
-#  name         :string
-#  shortname    :string
-#  sponsor_type :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  initials      :string
+#  international  :boolean          default(FALSE), not null
+#  name          :string
+#  shortname     :string
+#  sponsor_type  :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 FactoryBot.define do
   factory :sponsor do
@@ -16,5 +17,9 @@ FactoryBot.define do
     name { Faker::Company.name }
     shortname { 'ShortName' }
     sponsor_type { %w[private_type public_type mixed_type].sample }
+
+    trait :international do
+      international { true }
+    end
   end
 end

--- a/spec/features/patient_state_spec.rb
+++ b/spec/features/patient_state_spec.rb
@@ -6,21 +6,31 @@ RSpec.feature 'Patient state transitions', type: :feature, js: true do
   before { login_as admin, scope: :user }
 
   scenario 'an admin advances a prospect patient to candidate from the patients list' do
-    create(:patient) # starts in the prospect state
+    patient = create(:patient) # starts in the prospect state
 
     visit patients_path
 
-    # A prospect patient exposes the "Evaluar" (assess) transition to an admin.
-    expect(page).to have_button('Evaluar')
-
-    click_button 'Evaluar'
+    # Scope every assertion to THIS patient's row (dom_id) rather than the whole
+    # page. Under transactional fixtures a real-browser (Selenium) spec runs the
+    # app server on a separate thread sharing the test connection, and can
+    # occasionally see an adjacent example's not-yet-rolled-back patient — which
+    # made a page-wide `have_button('Evaluar')` an ambiguous match. Row-scoping
+    # makes the spec hermetic regardless of stray rows.
+    within "#patient_#{patient.id}" do
+      # A prospect patient exposes the "Evaluar" (assess) transition to an admin.
+      expect(page).to have_button('Evaluar')
+      click_button 'Evaluar'
+    end
 
     # After assess: prospect -> candidate. Assert on what the user sees (feature
-    # specs shouldn't reach into the DB across the server thread): the assess
-    # button is gone, the candidate-state actions appear, and the flash confirms.
+    # specs shouldn't reach into the DB across the server thread): the flash
+    # confirms, and within the row the assess button is gone and the
+    # candidate-state actions appear.
     expect(page).to have_content('Estado actualizado correctamente.')
-    expect(page).to have_no_button('Evaluar')
-    expect(page).to have_button('Aceptar')
-    expect(page).to have_button('Descartar')
+    within "#patient_#{patient.id}" do
+      expect(page).to have_no_button('Evaluar')
+      expect(page).to have_button('Aceptar')
+      expect(page).to have_button('Descartar')
+    end
   end
 end

--- a/spec/models/paper_trail_audit_spec.rb
+++ b/spec/models/paper_trail_audit_spec.rb
@@ -5,8 +5,18 @@ require 'rails_helper'
 RSpec.describe "PaperTrail audit trail on patient-related models", type: :model do
   it "versions a Patient on create and update" do
     patient = FactoryBot.create(:patient)
-    expect { patient.update!(notes: "seen in clinic") }
+    expect { patient.update!(country: "Colombia") }
       .to change { patient.versions.count }.by(1)
+  end
+
+  it "does NOT record encrypted patient fields in the audit trail (skip list)" do
+    patient = FactoryBot.create(:patient)
+    # Changing only encrypted fields produces no version, and never leaks their
+    # plaintext into versions.object_changes.
+    expect { patient.update!(illness_description: "psoriasis severa", notes: "x") }
+      .not_to change { patient.versions.count }
+    expect(patient.versions.flat_map { |v| (v.changeset || {}).keys })
+      .not_to include("illness_description", "notes", "firstname", "dob")
   end
 
   it "versions a VariableValue and can attribute it to a user" do

--- a/spec/models/paper_trail_audit_spec.rb
+++ b/spec/models/paper_trail_audit_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe "PaperTrail audit trail on patient-related models", type: :model 
 
   it "versions a Study (status/phase changes affect eligibility)" do
     study = FactoryBot.create(:study)
-    expect { study.update!(study_status: "completed") }
+    # Flip to a definitely-different status (the factory randomises it).
+    new_status = study.recruiting? ? "completed" : "recruiting"
+    expect { study.update!(study_status: new_status) }
       .to change { study.versions.count }.by(1)
   end
 end

--- a/spec/models/patient_encryption_spec.rb
+++ b/spec/models/patient_encryption_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+# Pseudonymization of identifiable patient data (INVIMA Anexo Técnico Tabla 7).
+RSpec.describe "Patient pseudonymization", type: :model do
+  let(:patient) do
+    FactoryBot.create(:patient,
+      firstname: "Juan", lastname: "Pérez", email: "juan@example.com",
+      dob: "1990-05-01", contact_number: "3015550000",
+      illness_description: "Psoriasis moderada", notes: "control 1")
+  end
+
+  def raw_column(id, col)
+    Patient.connection.select_value("SELECT #{col} FROM patients WHERE id = #{id}")
+  end
+
+  it "stores identifiable fields as ciphertext at rest" do
+    %w[firstname lastname email illness_description notes].each do |col|
+      stored = raw_column(patient.id, col)
+      expect(stored).to be_present
+      expect(stored).not_to include(patient.public_send(col))
+    end
+  end
+
+  it "decrypts transparently on read" do
+    reloaded = Patient.find(patient.id)
+    expect(reloaded.firstname).to eq("Juan")
+    expect(reloaded.fullname).to eq("Juan Pérez")
+    expect(reloaded.illness_description).to eq("Psoriasis moderada")
+  end
+
+  it "keeps dob usable as a Date despite being an encrypted string column" do
+    expect(patient.reload.dob).to eq(Date.new(1990, 5, 1))
+  end
+
+  it "supports exact-match search on deterministically-encrypted fields" do
+    expect(Patient.where(firstname: "Juan")).to include(patient)
+    expect(Patient.where(email: "juan@example.com")).to include(patient)
+  end
+
+  it "assigns a unique participant code on create" do
+    expect(patient.participant_code).to match(/\AP-[A-Z0-9]{8}\z/)
+    other = FactoryBot.create(:patient)
+    expect(other.participant_code).not_to eq(patient.participant_code)
+  end
+
+  it "owns its identity (reads its own column, not the delegated User)" do
+    user = FactoryBot.create(:user, :patient)
+    patient = user.userable
+    user.update!(firstname: "UserLevelName")
+    # Patient reads its own (factory-set) name, not the User's.
+    expect(patient.reload.firstname).not_to eq("UserLevelName")
+    expect(patient.firstname).to be_present
+  end
+
+  it "leaves other user types delegating identity to User (unchanged)" do
+    admin_user = FactoryBot.create(:user, :admin, firstname: "Ana", lastname: "Gómez")
+    expect(admin_user.userable.firstname).to eq("Ana")
+    expect(admin_user.userable.fullname).to eq("Ana Gómez")
+  end
+end

--- a/spec/requests/change_controls_spec.rb
+++ b/spec/requests/change_controls_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe "Change control (audit log)", type: :request do
+  let(:patient) { FactoryBot.create(:patient) }
+
+  def change_control_for(item, **params)
+    change_control_path(item.class.name, item.id, **params)
+  end
+
+  context "as an admin" do
+    let(:admin_user) { FactoryBot.create(:user, :admin) }
+    before { sign_in(admin_user, scope: :user) }
+
+    def make_change!(attrs)
+      PaperTrail.request(whodunnit: admin_user.id.to_s) { patient.update!(attrs) }
+    end
+
+    it "renders the change log with a field-level diff attributed to the user" do
+      make_change!(notes: "seen in clinic")
+
+      get change_control_for(patient)
+
+      expect(response).to be_successful
+      expect(response.body).to include("Control de cambios")
+      expect(response.body).to include("Notes") # humanized attribute name
+      expect(response.body).to include("seen in clinic")
+      expect(response.body).to include(admin_user.fullname.presence || admin_user.email)
+    end
+
+    it "filters by event type" do
+      make_change!(notes: "first")
+
+      # Only 'update' events exist; filtering to 'destroy' yields nothing.
+      get change_control_for(patient, event: "destroy")
+      expect(response.body).to include("No hay cambios que coincidan")
+
+      get change_control_for(patient, event: "update")
+      expect(response.body).to include("first")
+    end
+
+    it "exports the change log as CSV" do
+      make_change!(notes: "csv row")
+
+      get change_control_for(patient, format: :csv)
+
+      expect(response).to be_successful
+      expect(response.content_type).to include("text/csv")
+      expect(response.body).to include("fecha,evento,usuario,campo,antes,despues")
+      expect(response.body).to include("csv row")
+    end
+
+    it "404s for an untracked / unknown type" do
+      get change_control_path("Sponsor", 1)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "as a non-admin (patient)" do
+    before { sign_in(FactoryBot.create(:user, :patient), scope: :user) }
+
+    it "is blocked" do
+      get change_control_for(patient)
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  context "when signed out" do
+    it "redirects to sign in" do
+      get change_control_for(patient)
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/requests/change_controls_spec.rb
+++ b/spec/requests/change_controls_spec.rb
@@ -15,38 +15,40 @@ RSpec.describe "Change control (audit log)", type: :request do
       PaperTrail.request(whodunnit: admin_user.id.to_s) { patient.update!(attrs) }
     end
 
+    # Use a non-encrypted, tracked field (country). Encrypted fields like `notes`
+    # are intentionally skipped from the audit trail, so they never appear here.
     it "renders the change log with a field-level diff attributed to the user" do
-      make_change!(notes: "seen in clinic")
+      make_change!(country: "Colombia")
 
       get change_control_for(patient)
 
       expect(response).to be_successful
       expect(response.body).to include("Control de cambios")
-      expect(response.body).to include("Notes") # humanized attribute name
-      expect(response.body).to include("seen in clinic")
+      expect(response.body).to include("Country") # humanized attribute name
+      expect(response.body).to include("Colombia")
       expect(response.body).to include(admin_user.fullname.presence || admin_user.email)
     end
 
     it "filters by event type" do
-      make_change!(notes: "first")
+      make_change!(country: "Colombia")
 
       # Only 'update' events exist; filtering to 'destroy' yields nothing.
       get change_control_for(patient, event: "destroy")
       expect(response.body).to include("No hay cambios que coincidan")
 
       get change_control_for(patient, event: "update")
-      expect(response.body).to include("first")
+      expect(response.body).to include("Colombia")
     end
 
     it "exports the change log as CSV" do
-      make_change!(notes: "csv row")
+      make_change!(country: "Colombia")
 
       get change_control_for(patient, format: :csv)
 
       expect(response).to be_successful
       expect(response.content_type).to include("text/csv")
       expect(response.body).to include("fecha,evento,usuario,campo,antes,despues")
-      expect(response.body).to include("csv row")
+      expect(response.body).to include("Colombia")
     end
 
     it "404s for an untracked / unknown type" do

--- a/spec/requests/registration_consent_spec.rb
+++ b/spec/requests/registration_consent_spec.rb
@@ -36,6 +36,28 @@ RSpec.describe "Patient registration consent (Ley 1581)", type: :request do
     expect(consent.granted_at).to be_present
   end
 
+  context "when the study's sponsor is international" do
+    let(:study) { FactoryBot.create(:study, sponsor: FactoryBot.create(:sponsor, :international)) }
+
+    it "also records a distinct cross-border-transfer consent (Ley 1581 Art. 26)" do
+      post user_registration_path, params: signup_params(authorized: true)
+
+      user = User.last
+      types = user.consents.pluck(:document_type)
+      expect(types).to contain_exactly(
+        Consent::LEY_1581_HABEAS_DATA,
+        Consent::LEY_1581_CROSS_BORDER
+      )
+    end
+  end
+
+  it "does NOT record a cross-border consent for a domestic sponsor" do
+    post user_registration_path, params: signup_params(authorized: true)
+
+    types = User.last.consents.pluck(:document_type)
+    expect(types).to eq([ Consent::LEY_1581_HABEAS_DATA ])
+  end
+
   it "blocks registration entirely when authorization is not granted" do
     expect {
       post user_registration_path, params: signup_params(authorized: false)

--- a/spec/requests/registration_consent_spec.rb
+++ b/spec/requests/registration_consent_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+# Ley 1581 de 2012 habeas-data authorization must be captured as a discrete,
+# auditable step at registration, before any patient data is collected.
+RSpec.describe "Patient registration consent (Ley 1581)", type: :request do
+  let(:study) { FactoryBot.create(:study) }
+
+  def signup_params(authorized:)
+    {
+      user: {
+        email: "newpatient@example.com",
+        password: "password123",
+        password_confirmation: "password123",
+        data_processing_authorization: authorized ? "1" : "0"
+      }
+    }
+  end
+
+  # GET new first so the study_id lands in the session (how the real flow works).
+  before { get new_user_registration_path(study_id: study.id) }
+
+  it "creates the account + patient + an auditable Consent when authorization is granted" do
+    expect {
+      post user_registration_path, params: signup_params(authorized: true)
+    }.to change(User, :count).by(1)
+      .and change(Consent, :count).by(1)
+
+    user = User.last
+    expect(user.patient?).to be(true)
+
+    consent = Consent.last
+    expect(consent.user).to eq(user)
+    expect(consent.document_type).to eq(Consent::LEY_1581_HABEAS_DATA)
+    expect(consent.document_version).to eq(Consent::LEY_1581_CURRENT_VERSION)
+    expect(consent.purpose).to eq(Consent::PURPOSE_SENSITIVE_HEALTH)
+    expect(consent.granted_at).to be_present
+  end
+
+  it "blocks registration entirely when authorization is not granted" do
+    expect {
+      post user_registration_path, params: signup_params(authorized: false)
+    }.to change(User, :count).by(0)
+
+    expect(Consent.count).to eq(0)
+    expect(Patient.count).to eq(0)
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.body).to include("Debe autorizar")
+  end
+end

--- a/spec/views/criteria_variables/show.html.erb_spec.rb
+++ b/spec/views/criteria_variables/show.html.erb_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe "criteria_variables/show", type: :view do
 
     assign(:criteria_profile, profile)
     assign(:criteria_variable, variable)
+    # The view has an admin-only "Control de cambios" link gated on current_user,
+    # which isn't wired up in view specs (no Warden middleware).
+    allow(view).to receive(:current_user).and_return(nil)
 
     render template: 'criteria_variables/show'
 


### PR DESCRIPTION
## Summary

Closes remediation tasks **5** (pseudonymization), **3** (Ley 1581 consent), and **7** (cross-border safeguard). Brings the compliance checklist to **6/8** (only the legally-blocked tasks 4 and 8 remain).

> Stacked on #43 → #42. Review/merge those first; this PR's diff is only the pseudonymization + consent work.

## Task 5 — Patient pseudonymization
- Patient now **owns its identity** (delegation moved off the shared `User` into `DelegatesIdentityToUser`, used only by Admin/reps) — also fixes a latent write-Patient/read-User split.
- Encrypts `firstname`/`lastname`/`email`/`dob`/`contact_number`/`contact_address`/`id_number` (deterministic, searchable) + `illness_description`/`notes` (non-deterministic). `dob` date→string (+ `attribute :dob, :date`).
- `participant_code` (unique, `SecureRandom`, backfilled). `has_paper_trail skip:` the encrypted fields so plaintext never reaches `versions`.
- Keys via `config/initializers/active_record_encryption.rb` (ENV in prod). **Devise login (`User#email`) untouched** — verified end-to-end.

## Task 3 — Ley 1581 habeas-data authorization
- `Consent` model (immutable, versioned, `has_paper_trail`). Discrete authorization checkbox on the study-scoped sign-up; registration is a hard gate (no account/data without it). Also fixes a latent "Userable must exist" registration bug.

## Task 7 — Cross-border transfer
- `sponsors.international` flag + `Study#international_sponsor?`; enrolling in an international-sponsor study adds an Art. 26 clause and records a distinct cross-border `Consent`.

## ⚠️ Deploy notes
- **Production boot crashes if encryption keys are unset** — `heroku config:set AR_ENCRYPTION_PRIMARY_KEY=… DETERMINISTIC_KEY=… KEY_DERIVATION_SALT=…` before deploy.
- New migrations → `heroku run rails db:migrate`, then `rails patients:reencrypt` once to encrypt existing rows.

## Testing
Full suite green (186 examples, 0 failures). RuboCop clean. New specs: patient encryption, audit-skip, registration consent (incl. cross-border), delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)