### PR TITLE
Refactor the public home page mobile-first with a topic filter

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -67,6 +67,36 @@ $dark: $medici-dark;
   }
 }
 
+// Public home hero: logo + tagline + compact stat pills (the landing keeps
+// the roomier .stat-card for dashboards; pills read better on a phone).
+.home-hero-logo {
+  max-height: 220px;
+}
+
+.home-tagline {
+  max-width: 34rem;
+  font-size: calc(1.35rem + 0.9vw);
+  font-weight: 700;
+  color: $medici-dark;
+}
+
+.stat-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background-color: $medici-bg-subtle;
+  color: $medici-dark;
+  border: 1px solid rgba($medici-primary, 0.2);
+  border-radius: 50rem;
+  padding: 0.35rem 0.9rem;
+  font-weight: 500;
+
+  .stat-pill-value {
+    color: $medici-primary;
+    font-weight: 700;
+  }
+}
+
 // Model-specific card styling with colors matching the logo
 // Study card with green styling
 .study-card {

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -7,6 +7,11 @@ class StaticPagesController < ApplicationController
 
   def medici_home
     @cities = City.all.order(:name)
+    # Public topic filter: pills on the showcase link back here with ?topic=.
+    # An unknown topic just yields an empty (not erroring) study list.
+    @topics = Study.topics
+    @selected_topic = params[:topic].presence
+    @studies = @selected_topic ? Study.by_topic(@selected_topic) : Study.all
   end
 
   # Operation manual: what each role may do, the Colombian regulatory sources the

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -162,7 +162,7 @@ class StudiesController < SecureApplicationController
 
     # Only allow a list of trusted parameters through.
     def study_params
-      params.require(:study).permit(:city_id, :sponsor_id, :study_status, :scientific_title, :public_title, :short_title, :completed_at, :started_at, :first_patient_at, :global_ending_at, :study_phase, :inclusion_criteria, :exclusion_criteria, :sample_size, :main_intervention, :sex, :reviewed, :review_user_id)
+      params.require(:study).permit(:city_id, :sponsor_id, :study_status, :scientific_title, :public_title, :short_title, :topic, :completed_at, :started_at, :first_patient_at, :global_ending_at, :study_phase, :inclusion_criteria, :exclusion_criteria, :sample_size, :main_intervention, :sex, :reviewed, :review_user_id)
     end
 
   def set_commercial_data

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -10,16 +10,15 @@
 #  purpose          :string           not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  user_id          :bigint           not null
+#  patient_id       :bigint           not null
 #
 # Indexes
 #
-#  index_consents_on_user_id                    (user_id)
-#  index_consents_on_user_id_and_document_type  (user_id,document_type)
+#  index_consents_on_patient_id  (patient_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (patient_id => patients.id)
 #
 # An immutable record that a user granted a specific, versioned authorization —
 # the Ley 1581 de 2012 habeas-data authorization to process sensitive health data,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -19,11 +19,17 @@
 #  state               :string           default("prospect"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  study_id            :bigint
 #
 # Indexes
 #
 #  index_patients_on_participant_code  (participant_code) UNIQUE
 #  index_patients_on_state             (state)
+#  index_patients_on_study_id          (study_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (study_id => studies.id)
 #
 class Patient < ApplicationRecord
   include Userable

--- a/app/models/soap_note.rb
+++ b/app/models/soap_note.rb
@@ -16,7 +16,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (author_id => users.id)
+#  fk_rails_...  (author_id => users.id) ON DELETE => nullify
 #  fk_rails_...  (patient_id => patients.id)
 #
 # A SOAP note: the Subjective / Objective / Assessment / Plan format that is the

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -4,7 +4,7 @@
 #
 #  id            :bigint           not null, primary key
 #  initials      :string
-#  international  :boolean          default(FALSE), not null
+#  international :boolean          default(FALSE), not null
 #  name          :string
 #  shortname     :string
 #  sponsor_type  :string

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -18,6 +18,7 @@
 #  started_at         :date
 #  study_phase        :string
 #  study_status       :string
+#  topic              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  review_user_id     :integer
@@ -59,6 +60,15 @@ class Study < ApplicationRecord
   enum :study_phase, I: "I", II: "II", III: "III", IV: "IV"
 
   validates :public_title, :scientific_title, :short_title, presence: true
+
+  # Health-topic filter for the public home page. Free text entered by staff
+  # on the study form; a study with no topic simply never gets a pill and only
+  # appears under "Todos los estudios".
+  scope :by_topic, ->(topic) { where(topic: topic) }
+
+  def self.topics
+    where.not(topic: [ nil, "" ]).distinct.order(:topic).pluck(:topic)
+  end
 
   def cities_names
     cities = []

--- a/app/models/variable_value.rb
+++ b/app/models/variable_value.rb
@@ -2,26 +2,26 @@
 #
 # Table name: variable_values
 #
-#  id                :bigint           not null, primary key
-#  comparison_type   :string           not null
-#  conditions        :text
-#  criteria_order    :integer
-#  description       :text
-#  enabled           :boolean          default(TRUE), not null
-#  name              :string           not null
-#  qualitative_scale :text             default([]), not null, is an Array
-#  qualitative_value :string
-#  reference_value_1 :decimal(15, 6)
-#  reference_value_2 :decimal(15, 6)
-#  shown             :boolean          default(TRUE), not null
-#  value             :string
-#  value_type        :string           not null
-#  variable_type     :string           default("inclusion"), not null
-#  created_at        :datetime         not null
+#  id                   :bigint           not null, primary key
+#  comparison_type      :string           not null
+#  conditions           :text
+#  criteria_order       :integer
+#  description          :text
+#  enabled              :boolean          default(TRUE), not null
+#  name                 :string           not null
+#  qualitative_scale    :text             default([]), not null, is an Array
+#  qualitative_value    :string
+#  reference_value_1    :decimal(15, 6)
+#  reference_value_2    :decimal(15, 6)
+#  shown                :boolean          default(TRUE), not null
+#  value                :string
+#  value_type           :string           not null
+#  variable_type        :string           default("inclusion"), not null
+#  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  criteria_variable_id :bigint
-#  patient_id           :bigint           not null
 #  entered_by_id        :bigint
+#  patient_id           :bigint           not null
 #
 # Indexes
 #
@@ -33,7 +33,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (criteria_variable_id => criteria_variables.id)
+#  fk_rails_...  (criteria_variable_id => criteria_variables.id) ON DELETE => nullify
 #  fk_rails_...  (entered_by_id => users.id)
 #  fk_rails_...  (patient_id => patients.id)
 #

--- a/app/views/static_pages/_medici_showcase.html.erb
+++ b/app/views/static_pages/_medici_showcase.html.erb
@@ -1,23 +1,39 @@
-<div class="container-fluid mt-5 mb-5">
-  <h2 class="text-center mb-4"><%= t("static_pages.showcase.title") %></h2>
-  <div class="row">
-    <% Study.all.each do |study| %>
-      <div class="col-md-3 mb-4">
-        <div class="card health-card shadow-sm h-100">
-          <div class="card-header">
-            <%= study.public_title %>
-          </div>
-          <div class="card-body d-flex flex-column">
-            <h5 class="card-title"><%= Study.human_attribute_name(:scientific_title) %>: <%= study.scientific_title %></h5>
-            <h6 class="card-subtitle mb-2 text-muted"><%= Study.human_attribute_name(:short_title) %>: <%= study.short_title %></h6>
-            <p class="card-text"><%= Study.human_attribute_name(:study_status) %>: <%= study.study_status.capitalize %></p>
-            <div class="mt-auto d-grid gap-2">
-              <%= link_to t("static_pages.showcase.more_about"), study_about_path(study), class: "btn btn-primary w-100" %>
-              <%= link_to t("static_pages.showcase.participate"), new_participation_request_path(study_id: study.id), class: "btn btn-success w-100" %>
+<div class="container-fluid mb-5" id="estudios">
+  <h2 class="text-center mb-3"><%= t("static_pages.showcase.title") %></h2>
+
+  <%# Topic filter: one pill per topic in use, plus "all". Plain links back to
+      the home page (?topic=), so no JS is involved. %>
+  <nav class="d-flex flex-wrap justify-content-center gap-2 mb-4 px-3" aria-label="<%= t("static_pages.showcase.filter_label") %>">
+    <%= link_to t("static_pages.showcase.all_studies"), root_path(anchor: "estudios"),
+        class: "btn btn-sm rounded-pill px-3 #{@selected_topic ? 'btn-outline-primary' : 'btn-primary'}" %>
+    <% @topics.each do |topic| %>
+      <%= link_to topic, root_path(topic: topic, anchor: "estudios"),
+          class: "btn btn-sm rounded-pill px-3 #{@selected_topic == topic ? 'btn-primary' : 'btn-outline-primary'}" %>
+    <% end %>
+  </nav>
+
+  <% if @studies.any? %>
+    <div class="row">
+      <% @studies.each do |study| %>
+        <div class="col-md-3 mb-4">
+          <div class="card health-card shadow-sm h-100">
+            <div class="card-header">
+              <%= study.public_title %>
+            </div>
+            <div class="card-body d-flex flex-column">
+              <h5 class="card-title"><%= Study.human_attribute_name(:scientific_title) %>: <%= study.scientific_title %></h5>
+              <h6 class="card-subtitle mb-2 text-muted"><%= Study.human_attribute_name(:short_title) %>: <%= study.short_title %></h6>
+              <p class="card-text"><%= Study.human_attribute_name(:study_status) %>: <%= study.study_status.capitalize %></p>
+              <div class="mt-auto d-grid gap-2">
+                <%= link_to t("static_pages.showcase.more_about"), study_about_path(study), class: "btn btn-primary w-100" %>
+                <%= link_to t("static_pages.showcase.participate"), new_participation_request_path(study_id: study.id), class: "btn btn-success w-100" %>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    <% end %>
-  </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="text-center text-muted my-5"><%= t("static_pages.showcase.none_for_topic") %></p>
+  <% end %>
 </div>

--- a/app/views/static_pages/medici_home.html.erb
+++ b/app/views/static_pages/medici_home.html.erb
@@ -1,97 +1,63 @@
+<%# Mobile-first landing: logo → tagline → stat pills → city search → topic
+    pills + study cards (anonymous showcase) → login at the very end. The same
+    order reads naturally on desktop; widths are only constrained per section. %>
+<div class="container py-4 py-md-5">
+  <div class="text-center">
+    <%= image_tag "logo/medici_logo.jpeg", alt: t("static_pages.home.logo_alt"), class: "img-fluid rounded shadow-sm home-hero-logo" %>
+    <h1 class="home-tagline mx-auto mt-4 mb-3"><%= t("static_pages.home.tagline") %></h1>
 
-<div class="container py-5">
-  <div class="row">
-    <div class="col-md-8 mx-auto">
-      <div class="card health-card shadow-sm text-center">
+    <div class="d-flex flex-wrap justify-content-center gap-2 mb-4">
+      <span class="stat-pill"><span class="stat-pill-value"><%= Study.count %></span> <%= t("static_pages.home.stat_studies") %></span>
+      <span class="stat-pill"><span class="stat-pill-value"><%= TrialCenterFacility.count %></span> <%= t("static_pages.home.stat_facilities") %></span>
+      <span class="stat-pill"><span class="stat-pill-value"><%= Sponsor.count %></span> <%= t("static_pages.home.stat_sponsors") %></span>
+      <span class="stat-pill"><span class="stat-pill-value"><%= Patient.count %></span> <%= t("static_pages.home.stat_patients") %></span>
+    </div>
+  </div>
+
+  <% if policy(:static_page).search_by_city? %>
+    <div class="col-lg-8 mx-auto">
+      <div class="card health-card shadow-sm">
         <div class="card-header">
-          <h4 class="mb-0"><%= t("static_pages.home.header") %></h4>
+          <h5 class="mb-0"><%= t("static_pages.home.search_by_city_title") %></h5>
         </div>
-        <div class="card-body p-4">
-          <div class="text-center mb-4">
-            <%= image_tag "logo/medici_logo.jpeg", alt: t("static_pages.home.logo_alt"), class: "img-fluid rounded", style: "max-height: 200px;" %>
-          </div>
-          <h5 class="card-title mb-4"><%= t("static_pages.home.tagline") %></h5>
-          
-          <div class="row mb-4">
-            <div class="col-md-6 mb-3 mb-md-0">
-              <div class="stat-card">
-                <div class="stat-value"><%= Sponsor.count %></div>
-                <div class="stat-label"><%= t("static_pages.home.stat_sponsors") %></div>
+        <div class="card-body">
+          <%= form_with url: static_pages_search_by_city_path, method: :get, class: "row g-3 align-items-center" do |form| %>
+            <div class="col-md-10 mx-auto">
+              <div class="input-group">
+                <%= form.collection_select :city_id, @cities, :id, :name,
+                    { prompt: t("static_pages.home.select_city_prompt") },
+                    { class: "form-select", required: true } %>
+                <button type="submit" class="btn btn-primary">
+                  <i class="bi bi-search"></i> <%= t("static_pages.home.search_button") %>
+                </button>
+              </div>
+              <div class="form-text text-center mt-2">
+                <%= t("static_pages.home.search_help") %>
               </div>
             </div>
-            <div class="col-md-6">
-              <div class="stat-card">
-                <div class="stat-value"><%= TrialCenterFacility.count %></div>
-                <div class="stat-label"><%= t("static_pages.home.stat_facilities") %></div>
-              </div>
-            </div>
-          </div>
-          
-          <div class="row mb-4">
-            <div class="col-md-6 mb-3 mb-md-0">
-              <div class="stat-card">
-                <div class="stat-value"><%= Study.count %></div>
-                <div class="stat-label"><%= t("static_pages.home.stat_studies") %></div>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <div class="stat-card">
-                <%# Patients have no accounts, so counting Users would always say 0. %>
-                <div class="stat-value"><%= Patient.count %></div>
-                <div class="stat-label"><%= t("static_pages.home.stat_patients") %></div>
-              </div>
-            </div>
-          </div>
-          
-          <div class="mt-4 mb-4">
-            <% if user_signed_in? %>
-              <%= button_to t("static_pages.home.logout"), destroy_user_session_path, method: :delete, class: "btn btn-outline-primary btn-lg px-4" %>
-            <% else %>
-              <div class="d-grid gap-2 d-md-flex justify-content-md-center">
-                <%= link_to t("static_pages.home.login"), new_user_session_path, class: "btn btn-primary btn-lg px-4 me-md-2" %>
-                <%#= link_to 'Registrate', new_user_registration_path, class: "btn btn-outline-secondary btn-lg px-4" %>
-              </div>
-            <% end %>
-          </div>
-          
-          <% if policy(:static_page).search_by_city? %>
-          <div class="card health-card shadow-sm mt-4">
-            <div class="card-header">
-              <h5 class="mb-0"><%= t("static_pages.home.search_by_city_title") %></h5>
-            </div>
-            <div class="card-body">
-              <%= form_with url: static_pages_search_by_city_path, method: :get, class: "row g-3 align-items-center" do |form| %>
-                <div class="col-md-8 mx-auto">
-                  <div class="input-group">
-                    <%= form.collection_select :city_id, @cities, :id, :name,
-                        { prompt: t("static_pages.home.select_city_prompt") },
-                        { class: "form-select", required: true } %>
-                    <button type="submit" class="btn btn-primary">
-                      <i class="bi bi-search"></i> <%= t("static_pages.home.search_button") %>
-                    </button>
-                  </div>
-                  <div class="form-text text-center mt-2">
-                    <%= t("static_pages.home.search_help") %>
-                  </div>
-                </div>
-              <% end %>
-            </div>
-          </div>
           <% end %>
         </div>
       </div>
-      
-      <% if current_user.present? && policy(:static_page).home_navigation? %>
-        <div class="d-flex justify-content-center mt-4">
-          <div class="btn-group">
-            <%= link_to t("static_pages.home.view_studies"), studies_path, class: "btn btn-success me-2" %>
-            <%= link_to t("static_pages.home.view_sponsors"), sponsors_path, class: "btn btn-info me-2" %>
-            <%= link_to t("static_pages.home.view_facilities"), trial_center_facilities_path, class: "btn btn-secondary" %>
-          </div>
-        </div>
-      <% end %>
     </div>
-  </div>
+  <% end %>
+
+  <% if current_user.present? && policy(:static_page).home_navigation? %>
+    <div class="d-flex justify-content-center mt-4">
+      <div class="btn-group">
+        <%= link_to t("static_pages.home.view_studies"), studies_path, class: "btn btn-success me-2" %>
+        <%= link_to t("static_pages.home.view_sponsors"), sponsors_path, class: "btn btn-info me-2" %>
+        <%= link_to t("static_pages.home.view_facilities"), trial_center_facilities_path, class: "btn btn-secondary" %>
+      </div>
+    </div>
+  <% end %>
 </div>
 
-<%= render partial: 'medici_showcase' if current_user.blank? %>
+<%= render "medici_showcase" if current_user.blank? %>
+
+<div class="container pb-5 mt-2 text-center">
+  <% if user_signed_in? %>
+    <%= button_to t("static_pages.home.logout"), destroy_user_session_path, method: :delete, class: "btn btn-outline-primary btn-lg px-4 mx-auto" %>
+  <% else %>
+    <%= link_to t("static_pages.home.login"), new_user_session_path, class: "btn btn-outline-primary btn-lg px-5" %>
+  <% end %>
+</div>

--- a/app/views/studies/_form.html.erb
+++ b/app/views/studies/_form.html.erb
@@ -29,6 +29,18 @@
     </div>
 
     <div>
+      <%= form.label :topic, style: "display: block" %>
+      <%= form.text_field :topic, class: "form-control mb-3", list: "study-topic-options" %>
+      <%# Suggest existing topics so the same condition isn't spelled 3 ways,
+          splitting one home-page pill into several. %>
+      <datalist id="study-topic-options">
+        <% Study.topics.each do |topic| %>
+          <option value="<%= topic %>"></option>
+        <% end %>
+      </datalist>
+    </div>
+
+    <div>
       <%= form.label :study_status, style: "display: block" %>
       <%= form.select(:study_status,
                       [['Completed', 'completed'], ['Recruiting', 'recruiting']],

--- a/config/locales/content_users.es.yml
+++ b/config/locales/content_users.es.yml
@@ -103,7 +103,7 @@ es:
       stat_studies: "Estudios Clínicos"
       stat_patients: "Pacientes Registrados"
       logout: "Salir"
-      login: "Ingresa"
+      login: "Ingreso para usuario"
       search_by_city_title: "Buscar Estudios por Ciudad"
       select_city_prompt: "Selecciona una ciudad"
       search_button: "Buscar"
@@ -115,6 +115,9 @@ es:
       title: "Estudios Clínicos Disponibles"
       participate: "¡Quiero participar!"
       more_about: "Más sobre este estudio"
+      all_studies: "Todos los estudios"
+      filter_label: "Explora por tema de salud"
+      none_for_topic: "Por ahora no hay estudios en este tema."
     study_details:
       back_home: "Volver al inicio"
       description: "Descripción"

--- a/config/locales/content_users.fr.yml
+++ b/config/locales/content_users.fr.yml
@@ -101,7 +101,7 @@ fr:
       stat_studies: "Études cliniques"
       stat_patients: "Patients inscrits"
       logout: "Se déconnecter"
-      login: "Se connecter"
+      login: "Connexion utilisateur"
       search_by_city_title: "Rechercher des études par ville"
       select_city_prompt: "Sélectionnez une ville"
       search_button: "Rechercher"
@@ -113,6 +113,9 @@ fr:
       title: "Études cliniques disponibles"
       participate: "Je veux participer !"
       more_about: "En savoir plus sur cette étude"
+      all_studies: "Toutes les études"
+      filter_label: "Explorer par thème de santé"
+      none_for_topic: "Aucune étude sur ce thème pour le moment."
     study_details:
       back_home: "Retour à l’accueil"
       description: "Description"

--- a/config/locales/content_users.pt.yml
+++ b/config/locales/content_users.pt.yml
@@ -101,7 +101,7 @@ pt:
       stat_studies: "Estudos Clínicos"
       stat_patients: "Pacientes Registrados"
       logout: "Sair"
-      login: "Entrar"
+      login: "Acesso para usuário"
       search_by_city_title: "Buscar Estudos por Cidade"
       select_city_prompt: "Selecione uma cidade"
       search_button: "Buscar"
@@ -113,6 +113,9 @@ pt:
       title: "Estudos Clínicos Disponíveis"
       participate: "Quero participar!"
       more_about: "Mais sobre este estudo"
+      all_studies: "Todos os estudos"
+      filter_label: "Explore por tema de saúde"
+      none_for_topic: "Ainda não há estudos neste tema."
     study_details:
       back_home: "Voltar ao início"
       description: "Descrição"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -170,6 +170,7 @@ es:
         public_title: "Título público"
         scientific_title: "Título científico"
         short_title: "Título corto"
+        topic: "Tema de salud"
         study_status: "Estado del estudio"
         study_phase: "Fase del estudio"
         inclusion_criteria: "Criterios de inclusión"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -169,6 +169,7 @@ fr:
         public_title: "Titre public"
         scientific_title: "Titre scientifique"
         short_title: "Titre court"
+        topic: "Thème de santé"
         study_status: "Statut de l'étude"
         study_phase: "Phase de l'étude"
         inclusion_criteria: "Critères d'inclusion"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -169,6 +169,7 @@ pt:
         public_title: "Título público"
         scientific_title: "Título científico"
         short_title: "Título curto"
+        topic: "Tema de saúde"
         study_status: "Situação do estudo"
         study_phase: "Fase do estudo"
         inclusion_criteria: "Critérios de inclusão"

--- a/db/migrate/20260718181554_add_topic_to_studies.rb
+++ b/db/migrate/20260718181554_add_topic_to_studies.rb
@@ -1,0 +1,5 @@
+class AddTopicToStudies < ActiveRecord::Migration[8.0]
+  def change
+    add_column :studies, :topic, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_16_161000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_18_181554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -340,6 +340,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_16_161000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "short_title", default: ""
+    t.string "topic"
     t.index ["sponsor_id"], name: "index_studies_on_sponsor_id"
   end
 

--- a/spec/factories/complementary_informations.rb
+++ b/spec/factories/complementary_informations.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: complementary_informations
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  patient_id :bigint           not null
+#
+# Indexes
+#
+#  index_complementary_informations_on_patient_id  (patient_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#
 FactoryBot.define do
   factory :complementary_information do
     association :patient

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -6,7 +6,7 @@
 #  contact_address     :string
 #  contact_number      :string
 #  country             :string           default("")
-#  dob                 :date
+#  dob                 :string
 #  email               :string
 #  firstname           :string
 #  id_number           :string           default("")
@@ -14,14 +14,22 @@
 #  illness_description :text             default("")
 #  lastname            :string
 #  notes               :string
+#  participant_code    :string
 #  sex                 :string
 #  state               :string           default("prospect"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  study_id            :bigint
 #
 # Indexes
 #
-#  index_patients_on_state  (state)
+#  index_patients_on_participant_code  (participant_code) UNIQUE
+#  index_patients_on_state             (state)
+#  index_patients_on_study_id          (study_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (study_id => studies.id)
 #
 FactoryBot.define do
   factory :patient do

--- a/spec/factories/soap_notes.rb
+++ b/spec/factories/soap_notes.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: soap_notes
+#
+#  id             :bigint           not null, primary key
+#  encounter_date :date             not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  author_id      :bigint
+#  patient_id     :bigint           not null
+#
+# Indexes
+#
+#  index_soap_notes_on_author_id   (author_id)
+#  index_soap_notes_on_patient_id  (patient_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id) ON DELETE => nullify
+#  fk_rails_...  (patient_id => patients.id)
+#
 FactoryBot.define do
   factory :soap_note do
     association :patient

--- a/spec/factories/sponsors.rb
+++ b/spec/factories/sponsors.rb
@@ -2,9 +2,9 @@
 #
 # Table name: sponsors
 #
-#  id           :bigint           not null, primary key
+#  id            :bigint           not null, primary key
 #  initials      :string
-#  international  :boolean          default(FALSE), not null
+#  international :boolean          default(FALSE), not null
 #  name          :string
 #  shortname     :string
 #  sponsor_type  :string

--- a/spec/factories/studies.rb
+++ b/spec/factories/studies.rb
@@ -18,6 +18,7 @@
 #  started_at         :date
 #  study_phase        :string
 #  study_status       :string
+#  topic              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  review_user_id     :integer
@@ -41,6 +42,7 @@ FactoryBot.define do
     inclusion_criteria { Faker::Lorem.paragraph }
     exclusion_criteria { Faker::Lorem.paragraph }
     main_intervention { Faker::Lorem.sentence }
+    topic { [ "Dermatología", "Diabetes", "Hipertensión", "Oncología", "Salud mental" ].sample }
     sample_size { Faker::Number.between(from: 50, to: 1000) }
     sex { [ 'male', 'female', 'both' ].sample }
 

--- a/spec/models/criteria_profile_spec.rb
+++ b/spec/models/criteria_profile_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
+# == Schema Information
+#
+# Table name: criteria_profiles
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  study_id    :bigint
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_criteria_profiles_on_study_id              (study_id)
+#  index_criteria_profiles_on_study_id_and_user_id  (study_id,user_id)
+#  index_criteria_profiles_on_user_id               (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (study_id => studies.id)
+#  fk_rails_...  (user_id => users.id)
+#
 RSpec.describe CriteriaProfile, type: :model do
   describe "#evaluate" do
     let(:profile) { FactoryBot.create(:criteria_profile) }

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -8,7 +8,7 @@ require 'rails_helper'
 #  contact_address     :string
 #  contact_number      :string
 #  country             :string           default("")
-#  dob                 :date
+#  dob                 :string
 #  email               :string
 #  firstname           :string
 #  id_number           :string           default("")
@@ -16,14 +16,22 @@ require 'rails_helper'
 #  illness_description :text             default("")
 #  lastname            :string
 #  notes               :string
+#  participant_code    :string
 #  sex                 :string
 #  state               :string           default("prospect"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  study_id            :bigint
 #
 # Indexes
 #
-#  index_patients_on_state  (state)
+#  index_patients_on_participant_code  (participant_code) UNIQUE
+#  index_patients_on_state             (state)
+#  index_patients_on_study_id          (study_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (study_id => studies.id)
 #
 RSpec.describe Patient, type: :model do
   subject(:patient) { FactoryBot.create(:patient) }

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -18,6 +18,7 @@
 #  started_at         :date
 #  study_phase        :string
 #  study_status       :string
+#  topic              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  review_user_id     :integer

--- a/spec/requests/home_studies_spec.rb
+++ b/spec/requests/home_studies_spec.rb
@@ -13,4 +13,51 @@ RSpec.describe "Home page study showcase", type: :request do
     # not to Devise sign-up — that route no longer exists.
     expect(response.body).to include(new_participation_request_path(study_id: study.id))
   end
+
+  it "renders the mobile-first hero: tagline, stat pills, and the login button at the end" do
+    get root_path
+
+    expect(response.body).to include("Te ayudamos a encontrar un estudio")
+    expect(response.body).to include("stat-pill")
+    expect(response.body).to include("Ingreso para usuario")
+  end
+
+  it "offers a pill per topic in use plus an all-studies pill" do
+    FactoryBot.create(:study, topic: "Dermatología")
+    FactoryBot.create(:study, topic: "Oncología")
+
+    get root_path
+
+    expect(response.body).to include("Todos los estudios")
+    expect(response.body).to include("Dermatología")
+    expect(response.body).to include("Oncología")
+  end
+
+  it "filters the showcase when a topic pill is followed" do
+    derm = FactoryBot.create(:study, topic: "Dermatología")
+    onco = FactoryBot.create(:study, topic: "Oncología")
+
+    get root_path(topic: "Dermatología")
+
+    expect(response).to be_successful
+    expect(response.body).to include(derm.public_title)
+    expect(response.body).not_to include(onco.public_title)
+  end
+
+  it "keeps topicless studies visible in the unfiltered showcase, without a pill" do
+    bare = FactoryBot.create(:study, topic: nil)
+
+    get root_path
+
+    expect(response.body).to include(bare.public_title)
+  end
+
+  it "shows an empty state instead of erroring on an unknown topic" do
+    FactoryBot.create(:study, topic: "Dermatología")
+
+    get root_path(topic: "No existe")
+
+    expect(response).to be_successful
+    expect(response.body).to include("Por ahora no hay estudios en este tema.")
+  end
 end


### PR DESCRIPTION
Stacked on #48 (auto-retargets to main when it merges).

## What

Mobile-first home page in this order (desktop gets the same new elements): logo hero → the "Te ayudamos a encontrar un estudio que pueda mejorar tu condición de salud" tagline as the page title → the four platform stats as compact pills → search-by-city card → **topic filter pills** over the study showcase ("Todos los estudios" + one pill per topic in use) → the existing study cards unchanged → the login button, recaptioned **"Ingreso para usuario"**, at the very end. Signed-in users keep logout, nav buttons, and policy gates.

## Topic filter

`studies.topic` (new string column) powers the pills: staff set it on the study form, with a datalist suggesting topics already in use so one condition doesn't fragment into differently-spelled pills. Pills are plain links (`?topic=`); unknown/blank topics render an empty state; topicless studies appear only in the unfiltered view. Localized es/fr/pt.

Note: production studies have no topics yet, so only "Todos los estudios" will show until staff fill the field.

## Verification

- Headless-Chrome renders at 390px (mobile) and 1400px (desktop) match the requested layout.
- Suite: 352 examples, 0 failures. Brakeman + RuboCop clean.
- `?topic[]=a`, unicode, and blank params all render 200.
- New request specs: pills render, filter works, all-studies pill, empty state, topicless behavior, caption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh