### PR TITLE
Replace free-text study topic with Category (therapeutic areas)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,11 +142,12 @@ How the inclusion/exclusion rules engine is modeled — three tables, `app/model
 
 ### Global navbar search (added 2026-07-16)
 
-The navbar search box posts to `GET /search` (`SearchController#index`). The logic lives in `GlobalSearch` (`app/services/global_search.rb`, a PORO — `app/services/` is Zeitwerk-autoloaded). It returns results **grouped by record type** (`Group` structs: `:studies`, `:trial_centers`, `:reps`, `:patients`, `:cities`) and is gated the same two ways the rest of the app is:
+The navbar search box posts to `GET /search` (`SearchController#index`). The logic lives in `GlobalSearch` (`app/services/global_search.rb`, a PORO — `app/services/` is Zeitwerk-autoloaded). It returns results **grouped by record type** (`Group` structs: `:studies`, `:categories`, `:trial_centers`, `:reps`, `:patients`, `:cities`) and is gated the same two ways the rest of the app is:
 
 - **Permission** — each group only appears if the role has `can_show` on that resource (`Role#permits?`, the same flag the policies use). So a role with no `Patient` permission never gets a Patients group.
 - **Scope** — a trial centre rep is limited to **their branch's** records (studies, patients via `PatientPolicy::Scope`, the branch/facility itself, its reps, its cities). Admins see everything. Other permitted roles see all rows of what they may view (no branch to scope by), matching the inherited Pundit scope.
 - **Cities** carry the **user-scoped studies that run in them** (`CityResult` struct): studies of the branches located in that city, narrowed to the rep's branch. Note the city↔study link goes **through branches** (`City ↔ TrialCenterBranch ↔ Study`) — `Study` has no direct `cities` HABTM (it has `trial_cities`, a different thing).
+- **Categories** (added 2026-07-18): therapeutic areas (`Category` HABTM `Study`, seeded by `CategoriesSeeder` — reference data like roles) matched by name; each result carries the **user-scoped study count** (`CategoryResult` struct — a rep's count covers only their branch's studies) and links to the public home-page filter (`/?category=<id>`). Gated by the `Study` permission, since categories are study metadata.
 - **`SearchController` `skip_after_action :verify_authorized`** — there's no single resource to `authorize`; GlobalSearch enforces authorization per record type instead. This is the one sanctioned exception to the deny-by-default rule.
 - **Patient search caveat:** `Patient` name/email are deterministically encrypted, so search matches them by **exact value only** (ciphertext can't be `ILIKE`'d). `participant_code` is plaintext and matches partially. All other types match partially on their name/title columns.
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -7,11 +7,11 @@ class StaticPagesController < ApplicationController
 
   def medici_home
     @cities = City.all.order(:name)
-    # Public topic filter: pills on the showcase link back here with ?topic=.
-    # An unknown topic just yields an empty (not erroring) study list.
-    @topics = Study.topics
-    @selected_topic = params[:topic].presence
-    @studies = @selected_topic ? Study.by_topic(@selected_topic) : Study.all
+    # Public category filter: pills on the showcase link back here with
+    # ?category=<id>. An unknown/blank id just falls back to all studies.
+    @categories = Category.in_use
+    @selected_category = Category.find_by(id: params[:category])
+    @studies = @selected_category ? Study.by_category(@selected_category.id).distinct : Study.all
   end
 
   # Operation manual: what each role may do, the Colombian regulatory sources the

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -162,7 +162,7 @@ class StudiesController < SecureApplicationController
 
     # Only allow a list of trusted parameters through.
     def study_params
-      params.require(:study).permit(:city_id, :sponsor_id, :study_status, :scientific_title, :public_title, :short_title, :topic, :completed_at, :started_at, :first_patient_at, :global_ending_at, :study_phase, :inclusion_criteria, :exclusion_criteria, :sample_size, :main_intervention, :sex, :reviewed, :review_user_id)
+      params.require(:study).permit(:city_id, :sponsor_id, :study_status, :scientific_title, :public_title, :short_title, :completed_at, :started_at, :first_patient_at, :global_ending_at, :study_phase, :inclusion_criteria, :exclusion_criteria, :sample_size, :main_intervention, :sex, :reviewed, :review_user_id, category_ids: [])
     end
 
   def set_commercial_data

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,25 @@
+# A therapeutic area a study belongs to (Cardiología, Dermatología, …).
+# Reference data seeded by CategoriesSeeder (db/seeds/categories.rb); staff
+# attach 1..n to each study from the study form. Powers the public home-page
+# filter pills and the navbar search's category results.
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_categories_on_name  (name) UNIQUE
+#
+class Category < ApplicationRecord
+  has_and_belongs_to_many :studies
+
+  validates :name, presence: true, uniqueness: true
+
+  # Only categories that would produce a non-empty home-page filter.
+  scope :in_use, -> { joins(:studies).distinct.order(:name) }
+end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -18,7 +18,6 @@
 #  started_at         :date
 #  study_phase        :string
 #  study_status       :string
-#  topic              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  review_user_id     :integer
@@ -47,6 +46,9 @@ class Study < ApplicationRecord
   has_and_belongs_to_many :trial_center_branches
   has_and_belongs_to_many :users
   has_and_belongs_to_many :medications
+  # Therapeutic areas (reference data, see Category). 1..3 per study by
+  # convention; powers the public home filter and search category counts.
+  has_and_belongs_to_many :categories
   has_many :trial_center_facilities, through: :trial_center_branches
 
   has_many :articles, dependent: :destroy
@@ -61,14 +63,9 @@ class Study < ApplicationRecord
 
   validates :public_title, :scientific_title, :short_title, presence: true
 
-  # Health-topic filter for the public home page. Free text entered by staff
-  # on the study form; a study with no topic simply never gets a pill and only
-  # appears under "Todos los estudios".
-  scope :by_topic, ->(topic) { where(topic: topic) }
-
-  def self.topics
-    where.not(topic: [ nil, "" ]).distinct.order(:topic).pluck(:topic)
-  end
+  # Home-page category filter: studies attached to the given therapeutic area.
+  # A study with no category only appears under "Todos los estudios".
+  scope :by_category, ->(category_id) { joins(:categories).where(categories: { id: category_id }) }
 
   def cities_names
     cities = []

--- a/app/services/global_search.rb
+++ b/app/services/global_search.rb
@@ -16,6 +16,8 @@ class GlobalSearch
   Group = Struct.new(:type, :records, keyword_init: true)
   # A city plus the studies (already user-scoped) that run in it.
   CityResult = Struct.new(:city, :studies, keyword_init: true)
+  # A therapeutic area plus how many user-scoped studies belong to it.
+  CategoryResult = Struct.new(:category, :studies_count, keyword_init: true)
 
   LIMIT = 10
 
@@ -29,6 +31,7 @@ class GlobalSearch
 
     [
       studies_group,
+      categories_group,
       trial_centers_group,
       reps_group,
       patients_group,
@@ -49,6 +52,20 @@ class GlobalSearch
               .where("public_title ILIKE :q OR short_title ILIKE :q OR scientific_title ILIKE :q", q: ilike)
               .order(:public_title).limit(LIMIT)
     Group.new(type: :studies, records: records.to_a)
+  end
+
+  # Therapeutic areas matching by name, each with the number of studies in
+  # THIS user's scope — a branch rep sees their branch's count, an admin the
+  # platform's. Categories are study metadata, so the Study permission gates
+  # them, and a match with zero in-scope studies still shows (count 0) rather
+  # than pretending the category doesn't exist.
+  def categories_group
+    return unless can_show?(Study)
+
+    records = Category.where("name ILIKE ?", ilike).order(:name).limit(LIMIT).map do |category|
+      CategoryResult.new(category: category, studies_count: category_study_count(category))
+    end
+    Group.new(type: :categories, records: records)
   end
 
   def trial_centers_group
@@ -157,6 +174,10 @@ class GlobalSearch
       .joins(:trial_center_branches)
       .where(trial_center_branches: { id: city.trial_center_branch_ids })
       .distinct.order(:public_title).limit(LIMIT).to_a
+  end
+
+  def category_study_count(category)
+    study_scope.joins(:categories).where(categories: { id: category.id }).distinct.count
   end
 
   def reps_matching(scope)

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -31,6 +31,15 @@
               </li>
             <% end %>
 
+          <% when :categories %>
+            <% group.records.each do |result| %>
+              <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
+                <%# Links to the public home-page filter for that category. %>
+                <%= link_to result.category.name, root_path(category: result.category.id, anchor: "estudios"), class: "text-decoration-none fw-semibold" %>
+                <span class="badge bg-primary rounded-pill"><%= t("search.studies_count", count: result.studies_count) %></span>
+              </li>
+            <% end %>
+
           <% when :trial_centers %>
             <% group.records.each do |center| %>
               <li class="list-group-item d-flex justify-content-between align-items-center gap-2">

--- a/app/views/static_pages/_medici_showcase.html.erb
+++ b/app/views/static_pages/_medici_showcase.html.erb
@@ -1,14 +1,14 @@
 <div class="container-fluid mb-5" id="estudios">
   <h2 class="text-center mb-3"><%= t("static_pages.showcase.title") %></h2>
 
-  <%# Topic filter: one pill per topic in use, plus "all". Plain links back to
-      the home page (?topic=), so no JS is involved. %>
+  <%# Category filter: one pill per therapeutic area in use, plus "all".
+      Plain links back to the home page (?category=<id>), so no JS involved. %>
   <nav class="d-flex flex-wrap justify-content-center gap-2 mb-4 px-3" aria-label="<%= t("static_pages.showcase.filter_label") %>">
     <%= link_to t("static_pages.showcase.all_studies"), root_path(anchor: "estudios"),
-        class: "btn btn-sm rounded-pill px-3 #{@selected_topic ? 'btn-outline-primary' : 'btn-primary'}" %>
-    <% @topics.each do |topic| %>
-      <%= link_to topic, root_path(topic: topic, anchor: "estudios"),
-          class: "btn btn-sm rounded-pill px-3 #{@selected_topic == topic ? 'btn-primary' : 'btn-outline-primary'}" %>
+        class: "btn btn-sm rounded-pill px-3 #{@selected_category ? 'btn-outline-primary' : 'btn-primary'}" %>
+    <% @categories.each do |category| %>
+      <%= link_to category.name, root_path(category: category.id, anchor: "estudios"),
+          class: "btn btn-sm rounded-pill px-3 #{@selected_category == category ? 'btn-primary' : 'btn-outline-primary'}" %>
     <% end %>
   </nav>
 

--- a/app/views/studies/_form.html.erb
+++ b/app/views/studies/_form.html.erb
@@ -29,15 +29,12 @@
     </div>
 
     <div>
-      <%= form.label :topic, style: "display: block" %>
-      <%= form.text_field :topic, class: "form-control mb-3", list: "study-topic-options" %>
-      <%# Suggest existing topics so the same condition isn't spelled 3 ways,
-          splitting one home-page pill into several. %>
-      <datalist id="study-topic-options">
-        <% Study.topics.each do |topic| %>
-          <option value="<%= topic %>"></option>
-        <% end %>
-      </datalist>
+      <%= form.label :category_ids, Category.model_name.human(count: 2), style: "display: block" %>
+      <%# Therapeutic areas (seeded reference list). Ctrl/Cmd-click for more
+          than one; convention is 1–3 per study. %>
+      <%= form.collection_select :category_ids, Category.order(:name), :id, :name, {},
+          { multiple: true, class: "form-select mb-3", size: 8 } %>
+      <div class="form-text mb-3"><%= t("studies.form.categories_help") %></div>
     </div>
 
     <div>

--- a/config/locales/content_users.en.yml
+++ b/config/locales/content_users.en.yml
@@ -101,7 +101,7 @@ en:
       stat_studies: "Clinical Studies"
       stat_patients: "Registered Patients"
       logout: "Log out"
-      login: "Log in"
+      login: "User sign-in"
       search_by_city_title: "Search Studies by City"
       select_city_prompt: "Select a city"
       search_button: "Search"
@@ -113,6 +113,9 @@ en:
       title: "Available Clinical Studies"
       participate: "I want to participate!"
       more_about: "More about this study"
+      all_studies: "All studies"
+      filter_label: "Browse by health topic"
+      none_for_topic: "No studies in this topic yet."
     study_details:
       back_home: "Back to home"
       description: "Description"
@@ -126,6 +129,10 @@ en:
     search:
       title: "Clinical Studies in %{city}"
       back_to_search: "Back to search"
+      centers: "Centers running this study"
       view_details: "View details"
       participate: "I want to participate"
       none: "No clinical studies were found in %{city}."
+  studies:
+    form:
+      categories_help: "Select 1-3 therapeutic areas (Ctrl/Cmd + click for multiple)."

--- a/config/locales/content_users.es.yml
+++ b/config/locales/content_users.es.yml
@@ -135,3 +135,6 @@ es:
       view_details: "Ver detalles"
       participate: "Quiero participar"
       none: "No se encontraron estudios clínicos en %{city}."
+  studies:
+    form:
+      categories_help: "Selecciona de 1 a 3 áreas terapéuticas (Ctrl/Cmd + clic para varias)."

--- a/config/locales/content_users.fr.yml
+++ b/config/locales/content_users.fr.yml
@@ -133,3 +133,6 @@ fr:
       view_details: "Voir les détails"
       participate: "Je veux participer"
       none: "Aucune étude clinique n'a été trouvée à %{city}."
+  studies:
+    form:
+      categories_help: "Sélectionnez 1 à 3 aires thérapeutiques (Ctrl/Cmd + clic pour plusieurs)."

--- a/config/locales/content_users.pt.yml
+++ b/config/locales/content_users.pt.yml
@@ -133,3 +133,6 @@ pt:
       view_details: "Ver detalhes"
       participate: "Quero participar"
       none: "Nenhum estudo clínico foi encontrado em %{city}."
+  studies:
+    form:
+      categories_help: "Selecione de 1 a 3 áreas terapêuticas (Ctrl/Cmd + clique para várias)."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,11 @@ en:
       reps: "Representatives"
       patients: "Patients"
       cities: "Cities"
+      categories: "Categories"
+    studies_count:
+      zero: "0 studies"
+      one: "1 study"
+      other: "%{count} studies"
 
   common:
     edit: "Edit"
@@ -140,6 +145,9 @@ en:
     models:
       sponsor: "Sponsor"
       study: "Study"
+      category:
+        one: "Category"
+        other: "Categories"
       patient: "Patient"
       medication: "Medication"
       city: "City"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -43,6 +43,11 @@ es:
       reps: "Representantes"
       patients: "Pacientes"
       cities: "Ciudades"
+      categories: "Categorías"
+    studies_count:
+      zero: "0 estudios"
+      one: "1 estudio"
+      other: "%{count} estudios"
 
   common:
     edit: "Editar"
@@ -139,6 +144,9 @@ es:
     models:
       sponsor: "Patrocinador"
       study: "Estudio"
+      category:
+        one: "Categoría"
+        other: "Categorías"
       patient: "Paciente"
       medication: "Medicamento"
       city: "Ciudad"
@@ -170,7 +178,6 @@ es:
         public_title: "Título público"
         scientific_title: "Título científico"
         short_title: "Título corto"
-        topic: "Tema de salud"
         study_status: "Estado del estudio"
         study_phase: "Fase del estudio"
         inclusion_criteria: "Criterios de inclusión"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,6 +43,11 @@ fr:
       reps: "Représentants"
       patients: "Patients"
       cities: "Villes"
+      categories: "Catégories"
+    studies_count:
+      zero: "0 études"
+      one: "1 étude"
+      other: "%{count} études"
 
   common:
     edit: "Modifier"
@@ -138,6 +143,9 @@ fr:
     models:
       sponsor: "Promoteur"
       study: "Étude"
+      category:
+        one: "Catégorie"
+        other: "Catégories"
       patient: "Patient"
       medication: "Médicament"
       city: "Ville"
@@ -169,7 +177,6 @@ fr:
         public_title: "Titre public"
         scientific_title: "Titre scientifique"
         short_title: "Titre court"
-        topic: "Thème de santé"
         study_status: "Statut de l'étude"
         study_phase: "Phase de l'étude"
         inclusion_criteria: "Critères d'inclusion"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -43,6 +43,11 @@ pt:
       reps: "Representantes"
       patients: "Pacientes"
       cities: "Cidades"
+      categories: "Categorias"
+    studies_count:
+      zero: "0 estudos"
+      one: "1 estudo"
+      other: "%{count} estudos"
 
   common:
     edit: "Editar"
@@ -138,6 +143,9 @@ pt:
     models:
       sponsor: "Patrocinador"
       study: "Estudo"
+      category:
+        one: "Categoria"
+        other: "Categorias"
       patient: "Paciente"
       medication: "Medicamento"
       city: "Cidade"
@@ -169,7 +177,6 @@ pt:
         public_title: "Título público"
         scientific_title: "Título científico"
         short_title: "Título curto"
-        topic: "Tema de saúde"
         study_status: "Situação do estudo"
         study_phase: "Fase do estudo"
         inclusion_criteria: "Critérios de inclusão"

--- a/db/migrate/20260718195017_create_categories.rb
+++ b/db/migrate/20260718195017_create_categories.rb
@@ -1,0 +1,15 @@
+class CreateCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :categories, :name, unique: true
+
+    create_join_table :categories, :studies do |t|
+      t.index [ :category_id, :study_id ], unique: true
+      t.index :study_id
+    end
+  end
+end

--- a/db/migrate/20260718195018_remove_topic_from_studies.rb
+++ b/db/migrate/20260718195018_remove_topic_from_studies.rb
@@ -1,0 +1,7 @@
+class RemoveTopicFromStudies < ActiveRecord::Migration[8.0]
+  # Superseded within a day by the categories join (a study belongs to several
+  # therapeutic areas, and free text fragments into differently-spelled pills).
+  def change
+    remove_column :studies, :topic, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_18_181554) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_18_195018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -100,6 +100,20 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_18_181554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["study_id"], name: "index_campaigns_on_study_id"
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "categories_studies", id: false, force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "study_id", null: false
+    t.index ["category_id", "study_id"], name: "index_categories_studies_on_category_id_and_study_id", unique: true
+    t.index ["study_id"], name: "index_categories_studies_on_study_id"
   end
 
   create_table "cities", force: :cascade do |t|
@@ -340,7 +354,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_18_181554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "short_title", default: ""
-    t.string "topic"
     t.index ["sponsor_id"], name: "index_studies_on_sponsor_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,11 @@ require 'factory_bot'
 require_relative 'seeds/roles_and_permissions'
 RolesAndPermissionsSeeder.seed!
 
+# Study categories (therapeutic areas) — reference data for the study form's
+# dropdown, the public home-page filter, and the navbar search.
+require_relative 'seeds/categories'
+CategoriesSeeder.seed!
+
 # ---------------------------------------------------------------------------
 # All sample data below is intentionally DISABLED (commented out).
 #
@@ -78,6 +83,8 @@ RolesAndPermissionsSeeder.seed!
 #   end
 #   FactoryBot.create_list(:study, (1..5).to_a.sample, sponsor: sponsor) do |study|
 #     study.trial_center_branches << TrialCenterBranch.find(TrialCenterBranch.ids.sample((1..3).to_a.sample))
+#     # Every study belongs to 1..3 therapeutic areas (the seeded Category list).
+#     study.categories << Category.order("RANDOM()").limit(rand(1..3))
 #     FactoryBot.create_list(:article, (1..3).to_a.sample, study: study)
 #     FactoryBot.create_list(:contact, (1..2).to_a.sample, study: study)
 #     FactoryBot.create_list(:result, (1..4).to_a.sample, study: study)

--- a/db/seeds/categories.rb
+++ b/db/seeds/categories.rb
@@ -1,0 +1,39 @@
+# Idempotent seeder for the study categories (therapeutic areas). Reference
+# data required for the study form's category dropdown, the public home-page
+# filter, and the navbar search — safe for every environment, like
+# RolesAndPermissionsSeeder. Re-running never duplicates or renames anything
+# (staff-added categories are left untouched).
+#
+# The list follows the therapeutic-area taxonomy used in clinical-trial
+# registries (ClinicalTrials.gov browse conditions / MSD-style specialty
+# areas), in Spanish, since the platform is Spanish-first.
+module CategoriesSeeder
+  NAMES = [
+    "Cardiología",
+    "Dermatología",
+    "Endocrinología y diabetes",
+    "Enfermedades infecciosas",
+    "Gastroenterología",
+    "Geriatría",
+    "Ginecología y obstetricia",
+    "Hematología",
+    "Inmunología y alergias",
+    "Nefrología",
+    "Neumología",
+    "Neurología",
+    "Nutrición y metabolismo",
+    "Oftalmología",
+    "Oncología",
+    "Ortopedia y traumatología",
+    "Otorrinolaringología",
+    "Pediatría",
+    "Psiquiatría y salud mental",
+    "Reumatología",
+    "Urología",
+    "Vacunas"
+  ].freeze
+
+  def self.seed!
+    NAMES.each { |name| Category.find_or_create_by!(name: name) }
+  end
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_categories_on_name  (name) UNIQUE
+#
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "Categoría #{n}" }
+  end
+end

--- a/spec/factories/studies.rb
+++ b/spec/factories/studies.rb
@@ -18,7 +18,6 @@
 #  started_at         :date
 #  study_phase        :string
 #  study_status       :string
-#  topic              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  review_user_id     :integer
@@ -42,7 +41,12 @@ FactoryBot.define do
     inclusion_criteria { Faker::Lorem.paragraph }
     exclusion_criteria { Faker::Lorem.paragraph }
     main_intervention { Faker::Lorem.sentence }
-    topic { [ "Dermatología", "Diabetes", "Hipertensión", "Oncología", "Salud mental" ].sample }
+
+    # Categories are seeded reference data, not auto-attached: specs that need
+    # them opt in via the trait so counts stay deterministic.
+    trait :with_categories do
+      after(:create) { |study| study.categories << FactoryBot.create(:category) }
+    end
     sample_size { Faker::Number.between(from: 50, to: 1000) }
     sex { [ 'male', 'female', 'both' ].sample }
 

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -18,7 +18,6 @@
 #  started_at         :date
 #  study_phase        :string
 #  study_status       :string
-#  topic              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  review_user_id     :integer

--- a/spec/requests/home_studies_spec.rb
+++ b/spec/requests/home_studies_spec.rb
@@ -22,42 +22,51 @@ RSpec.describe "Home page study showcase", type: :request do
     expect(response.body).to include("Ingreso para usuario")
   end
 
-  it "offers a pill per topic in use plus an all-studies pill" do
-    FactoryBot.create(:study, topic: "Dermatología")
-    FactoryBot.create(:study, topic: "Oncología")
+  it "offers a pill per category in use plus an all-studies pill" do
+    derm = FactoryBot.create(:category, name: "Dermatología")
+    onco = FactoryBot.create(:category, name: "Oncología")
+    FactoryBot.create(:study).categories << derm
+    FactoryBot.create(:study).categories << onco
+    FactoryBot.create(:category, name: "Sin estudios aún")
 
     get root_path
 
     expect(response.body).to include("Todos los estudios")
     expect(response.body).to include("Dermatología")
     expect(response.body).to include("Oncología")
+    # A category no study uses yet gets no pill.
+    expect(response.body).not_to include("Sin estudios aún")
   end
 
-  it "filters the showcase when a topic pill is followed" do
-    derm = FactoryBot.create(:study, topic: "Dermatología")
-    onco = FactoryBot.create(:study, topic: "Oncología")
+  it "filters the showcase when a category pill is followed" do
+    derm = FactoryBot.create(:category, name: "Dermatología")
+    onco = FactoryBot.create(:category, name: "Oncología")
+    derm_study = FactoryBot.create(:study)
+    onco_study = FactoryBot.create(:study)
+    derm_study.categories << derm
+    onco_study.categories << onco
 
-    get root_path(topic: "Dermatología")
+    get root_path(category: derm.id)
 
     expect(response).to be_successful
-    expect(response.body).to include(derm.public_title)
-    expect(response.body).not_to include(onco.public_title)
+    expect(response.body).to include(derm_study.public_title)
+    expect(response.body).not_to include(onco_study.public_title)
   end
 
-  it "keeps topicless studies visible in the unfiltered showcase, without a pill" do
-    bare = FactoryBot.create(:study, topic: nil)
+  it "keeps categoryless studies visible in the unfiltered showcase" do
+    bare = FactoryBot.create(:study)
 
     get root_path
 
     expect(response.body).to include(bare.public_title)
   end
 
-  it "shows an empty state instead of erroring on an unknown topic" do
-    FactoryBot.create(:study, topic: "Dermatología")
+  it "falls back to all studies on an unknown category id" do
+    study = FactoryBot.create(:study, :with_categories)
 
-    get root_path(topic: "No existe")
+    get root_path(category: 999_999)
 
     expect(response).to be_successful
-    expect(response.body).to include("Por ahora no hay estudios en este tema.")
+    expect(response.body).to include(study.public_title)
   end
 end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -34,6 +34,32 @@ RSpec.describe "Search", type: :request do
     end
   end
 
+  describe "category results" do
+    let!(:cardiologia) { FactoryBot.create(:category, name: "Cardiología") }
+
+    before { cardiologia.studies << [ study_a, study_b ] }
+
+    it "shows matched categories with the platform-wide study count for admins" do
+      sign_in FactoryBot.create(:user, :admin)
+
+      get search_path(q: "Cardiología")
+
+      expect(response.body).to include(I18n.t("search.types.categories"))
+      expect(response.body).to include("Cardiología")
+      expect(response.body).to include("2 estudios")
+    end
+
+    it "counts only the rep's own branch's studies" do
+      rep = FactoryBot.create(:user, userable: FactoryBot.create(:trial_center_branch_rep, trial_center_branch: branch_a))
+      sign_in rep
+
+      get search_path(q: "Cardiología")
+
+      expect(response.body).to include("Cardiología")
+      expect(response.body).to include(">1 estudio<")
+    end
+  end
+
   describe "as a trial centre rep on branch A" do
     before do
       rep = FactoryBot.create(:user, userable: FactoryBot.create(:trial_center_branch_rep, trial_center_branch: branch_a))


### PR DESCRIPTION
## What

`studies.topic` (born yesterday, zero values in production — verified via `pg:psql` during review) is replaced by a proper **Category** table with a HABTM join to Study: a study belongs to several therapeutic areas, and free text would fragment one condition into differently-spelled pills.

- **22 seeded categories** following the therapeutic-area taxonomy of clinical-trial registries, in Spanish (Cardiología, Dermatología, Neurología, Oncología, …) — `CategoriesSeeder`, idempotent, active in `db/seeds.rb` as reference data like the roles.
- **Study form**: multi-select dropdown (`category_ids`), 1–3 per study by convention, help text in es/en/fr/pt. Empty selection clears (hidden blank input verified).
- **Home filter redone**: pills from `Category.in_use`, `?category=<id>`, unknown id falls back to all studies.
- **Navbar global search**: new *Categorías* group — name match, gated by the `Study` permission, each result showing the **study count within the user's scope** (a branch rep sees their branch's count, an admin the platform's), linking to the public home filter.
- Sample-studies seed block now assigns `rand(1..3)` categories to every study.

## Verification

- Suite: 357 examples, 0 failures; Brakeman + RuboCop clean.
- Headless-Chrome renders (shared in session): home pills, Neurología-filtered view, search results with per-category counts.
- Adversarial review workflow: zero confirmed findings.
- `?category[]=`-style params, unknown ids, and all four locales (en falls back to es where untranslated) probed.

## Deploy notes

`heroku run rails db:migrate` (creates categories + join, drops topic), then `heroku run rails db:seed` (idempotent — seeds the 22 categories). Staff then categorize the existing studies via the study form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh