### PR TITLE
Cities as a striped table with user-scoped studies and a per-city detail

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -3,11 +3,24 @@ class CitiesController < SecureApplicationController
 
   # GET /cities or /cities.json
   def index
-    @cities = City.all
+    @cities = City.order(:name)
+    # Studies per city, narrowed to the signed-in user (a branch rep sees only
+    # their branch's studies; admins and other permitted roles see all) — one
+    # query for the whole table. The city↔study link goes through branches.
+    pairs = Study.joins(:trial_center_branches)
+                 .joins("INNER JOIN cities_trial_center_branches cctb ON cctb.trial_center_branch_id = trial_center_branches.id")
+                 .where(trial_center_branches: { id: user_branch_scope.select(:id) })
+                 .select("studies.*, cctb.city_id AS city_id")
+                 .distinct
+    @studies_by_city = pairs.group_by(&:city_id)
   end
 
   # GET /cities/1 or /cities/1.json
   def show
+    # The user's branches located in this city, with the studies they run.
+    @branches = user_branch_scope.joins(:cities).where(cities: { id: @city.id })
+                                 .includes(:trial_center_facility, :studies)
+                                 .distinct.order(:name)
   end
 
   # GET /cities/new
@@ -58,6 +71,19 @@ class CitiesController < SecureApplicationController
   end
 
   private
+    # Same scoping rule as GlobalSearch: admin = every branch, a trial centre
+    # rep = only their own branch, other permitted roles = all rows.
+    def user_branch_scope
+      return TrialCenterBranch.all if current_user.admin?
+
+      if current_user.trial_center_branch_rep?
+        branch = current_user.userable.trial_center_branch
+        return branch ? TrialCenterBranch.where(id: branch.id) : TrialCenterBranch.none
+      end
+
+      TrialCenterBranch.all
+    end
+
     # Use callbacks to share common setup or constraints between actions.
     def set_city
       @city = City.find(params[:id])

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -1,25 +1,49 @@
 <div class="container">
-  <div class="row">
-    <div class="col-12 mx-auto">
-      <p style="color: green"><%= notice %></p>
+  <p style="color: green"><%= notice %></p>
+  <% content_for :title, t("nav.cities") %>
 
-      <% content_for :title, t("nav.cities") %>
-      <%= link_to t("cities.new"), new_city_path %> |
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1><%= t("nav.cities") %></h1>
+    <div>
       <%= link_to t("cities.home_link"), static_pages_medici_home_path %>
-      <h1><%= t("nav.cities") %></h1>
-
-
-        <div class="row">
-            <% @cities.each do |city| %>
-
-            <div class="col-3">
-              <%= render partial: 'city', locals: { city: city } %>
-            </div>
-
-            <% end %>
-        </div>
-      <%= link_to t("cities.new"), new_city_path %> |
-      <%= link_to t("cities.home_link"), static_pages_medici_home_path %>
+      <% if policy(City).new? %>
+        | <%= link_to t("cities.new"), new_city_path, class: "btn btn-primary" %>
+      <% end %>
     </div>
   </div>
+
+  <table class="table table-striped align-middle">
+    <thead>
+      <tr>
+        <th><%= City.human_attribute_name(:name) %></th>
+        <%# Studies running in the city, narrowed to the signed-in user
+            (admins see all, a branch rep only their branch's). %>
+        <th><%= t("cities.your_studies") %></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @cities.each do |city| %>
+        <% studies = @studies_by_city.fetch(city.id, []) %>
+        <tr>
+          <td><%= link_to city.name, city_path(city), class: "fw-semibold text-decoration-none" %></td>
+          <td>
+            <% if studies.any? %>
+              <% studies.each do |study| %>
+                <%= link_to study.public_title, study_path(study), class: "badge bg-light text-primary border text-decoration-none me-1" %>
+              <% end %>
+            <% else %>
+              <span class="text-muted small"><%= t("cities.no_studies") %></span>
+            <% end %>
+          </td>
+          <td class="text-end">
+            <%= link_to t("cities.view_details"), city_path(city), class: "btn btn-sm btn-outline-primary" %>
+            <% if policy(city).edit? %>
+              <%= link_to t("common.edit"), edit_city_path(city), class: "btn btn-sm btn-outline-secondary" %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -1,14 +1,48 @@
-<div class="container-fluid">
-  <div class="row">
-    <div class="col-4 mx-auto">
-      <p style="color: green"><%= notice %></p>
+<div class="container">
+  <p style="color: green"><%= notice %></p>
 
-      <%= render @city %>
-
-      <div>
-        <%= link_to t("common.edit"), edit_city_path(@city) %> |
-        <%= link_to t("cities.back_to_list"), cities_path %>
-      </div>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1><%= @city.name %></h1>
+    <div>
+      <% if policy(@city).edit? %>
+        <%= link_to t("common.edit"), edit_city_path(@city), class: "btn btn-outline-secondary" %>
+      <% end %>
+      <%= link_to t("cities.back_to_list"), cities_path, class: "btn btn-link" %>
     </div>
   </div>
+
+  <%# The signed-in user's branches located in this city, with the studies
+      each one runs — a branch rep sees only their own branch here. %>
+  <h5 class="mb-3"><%= t("cities.your_branches") %></h5>
+
+  <% if @branches.any? %>
+    <table class="table table-striped align-middle">
+      <thead>
+        <tr>
+          <th><%= TrialCenterBranch.model_name.human %></th>
+          <th><%= TrialCenterFacility.model_name.human %></th>
+          <th><%= t("cities.branch_studies") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @branches.each do |branch| %>
+          <tr>
+            <td><%= link_to branch.name, branch, class: "fw-semibold text-decoration-none" %></td>
+            <td><%= branch.trial_center_facility.name %></td>
+            <td>
+              <% if branch.studies.any? %>
+                <% branch.studies.each do |study| %>
+                  <%= link_to study.public_title, study_path(study), class: "badge bg-light text-primary border text-decoration-none me-1" %>
+                <% end %>
+              <% else %>
+                <span class="text-muted small"><%= t("cities.no_studies") %></span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="text-muted"><%= t("cities.no_branches") %></p>
+  <% end %>
 </div>

--- a/config/locales/content_resources.en.yml
+++ b/config/locales/content_resources.en.yml
@@ -37,6 +37,12 @@ en:
     new: "New city"
     edit_title: "Edit city"
     back_to_list: "Back to cities"
+    your_studies: "Studies (per your role)"
+    your_branches: "Branches related to you in this city"
+    branch_studies: "Branch studies"
+    no_studies: "No studies"
+    no_branches: "No branches related to you in this city."
+    view_details: "View details"
 
   contacts:
     created: "Contact was successfully created."

--- a/config/locales/content_resources.es.yml
+++ b/config/locales/content_resources.es.yml
@@ -37,6 +37,12 @@ es:
     new: "Nueva ciudad"
     edit_title: "Edición de ciudad"
     back_to_list: "Retornar a ciudades"
+    your_studies: "Estudios (según tu rol)"
+    your_branches: "Sedes relacionadas contigo en esta ciudad"
+    branch_studies: "Estudios de la sede"
+    no_studies: "Sin estudios"
+    no_branches: "No hay sedes relacionadas contigo en esta ciudad."
+    view_details: "Ver detalles"
 
   contacts:
     created: "El contacto se creó correctamente."

--- a/config/locales/content_resources.fr.yml
+++ b/config/locales/content_resources.fr.yml
@@ -37,6 +37,12 @@ fr:
     new: "Nouvelle ville"
     edit_title: "Modification de la ville"
     back_to_list: "Retour aux villes"
+    your_studies: "Études (selon votre rôle)"
+    your_branches: "Sites liés à vous dans cette ville"
+    branch_studies: "Études du site"
+    no_studies: "Aucune étude"
+    no_branches: "Aucun site lié à vous dans cette ville."
+    view_details: "Voir les détails"
 
   contacts:
     created: "Le contact a été créé avec succès."

--- a/config/locales/content_resources.pt.yml
+++ b/config/locales/content_resources.pt.yml
@@ -37,6 +37,12 @@ pt:
     new: "Nova cidade"
     edit_title: "Edição de cidade"
     back_to_list: "Voltar para cidades"
+    your_studies: "Estudos (conforme seu papel)"
+    your_branches: "Sedes relacionadas a você nesta cidade"
+    branch_studies: "Estudos da sede"
+    no_studies: "Sem estudos"
+    no_branches: "Não há sedes relacionadas a você nesta cidade."
+    view_details: "Ver detalhes"
 
   contacts:
     created: "O contato foi criado com sucesso."

--- a/spec/requests/cities_spec.rb
+++ b/spec/requests/cities_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "Cities", type: :request do
+  let(:city) { FactoryBot.create(:city) }
+  let(:branch_a) { FactoryBot.create(:trial_center_branch, name: "Sede Norte") }
+  let(:branch_b) { FactoryBot.create(:trial_center_branch, name: "Sede Sur") }
+  let!(:study_a) { FactoryBot.create(:study, public_title: "Estudio Alfa").tap { |s| s.trial_center_branches << branch_a } }
+  let!(:study_b) { FactoryBot.create(:study, public_title: "Estudio Beta").tap { |s| s.trial_center_branches << branch_b } }
+
+  before do
+    branch_a.cities << city
+    branch_b.cities << city
+  end
+
+  describe "as an admin" do
+    before { sign_in(FactoryBot.create(:user, :admin), scope: :user) }
+
+    it "lists cities in a striped table with every study running in each city" do
+      get cities_path
+
+      expect(response).to be_successful
+      expect(response.body).to include("table-striped")
+      expect(response.body).to include("Estudio Alfa")
+      expect(response.body).to include("Estudio Beta")
+    end
+
+    it "details a city with all its branches and their studies" do
+      get city_path(city)
+
+      expect(response).to be_successful
+      expect(response.body).to include("Sede Norte")
+      expect(response.body).to include("Sede Sur")
+      expect(response.body).to include("Estudio Alfa")
+      expect(response.body).to include("Estudio Beta")
+    end
+  end
+
+  describe "as a trial centre rep on branch A" do
+    before do
+      rep = FactoryBot.create(:trial_center_branch_rep, trial_center_branch: branch_a)
+      sign_in(FactoryBot.create(:user, userable: rep), scope: :user)
+    end
+
+    it "sees only their branch's studies on the index" do
+      get cities_path
+
+      expect(response.body).to include("Estudio Alfa")
+      expect(response.body).not_to include("Estudio Beta")
+    end
+
+    it "sees only their branch on the city detail" do
+      get city_path(city)
+
+      expect(response.body).to include("Sede Norte")
+      expect(response.body).not_to include("Sede Sur")
+      expect(response.body).not_to include("Estudio Beta")
+    end
+  end
+end


### PR DESCRIPTION
## What

- **Cities index**: striped table (name · studies · actions) replacing the old name-only cards. The studies column is **scoped to the signed-in user** — admins see every study running in the city, a trial centre rep only their branch's — resolved in a single grouped query.
- **City detail**: picking a city lists the user's branches located there, with facility and the studies each branch runs. Same scoping rule as GlobalSearch (`admin = all, rep = own branch, other permitted roles = all rows`).

## Verification

- Request specs: admin sees all branches/studies; a rep on branch A never sees branch B or its studies, on either page.
- Suite: 369 examples, 0 failures; Brakeman + RuboCop clean.
- Headless-Chrome renders shared in session.

No migration; no deploy prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh