### PR TITLE
Drop the redundant "Ver detalles" button from the cities table

### DIFF
--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -37,7 +37,6 @@
             <% end %>
           </td>
           <td class="text-end">
-            <%= link_to t("cities.view_details"), city_path(city), class: "btn btn-sm btn-outline-primary" %>
             <% if policy(city).edit? %>
               <%= link_to t("common.edit"), edit_city_path(city), class: "btn btn-sm btn-outline-secondary" %>
             <% end %>

--- a/config/locales/content_resources.en.yml
+++ b/config/locales/content_resources.en.yml
@@ -42,7 +42,6 @@ en:
     branch_studies: "Branch studies"
     no_studies: "No studies"
     no_branches: "No branches related to you in this city."
-    view_details: "View details"
 
   contacts:
     created: "Contact was successfully created."

--- a/config/locales/content_resources.es.yml
+++ b/config/locales/content_resources.es.yml
@@ -42,7 +42,6 @@ es:
     branch_studies: "Estudios de la sede"
     no_studies: "Sin estudios"
     no_branches: "No hay sedes relacionadas contigo en esta ciudad."
-    view_details: "Ver detalles"
 
   contacts:
     created: "El contacto se creó correctamente."

--- a/config/locales/content_resources.fr.yml
+++ b/config/locales/content_resources.fr.yml
@@ -42,7 +42,6 @@ fr:
     branch_studies: "Études du site"
     no_studies: "Aucune étude"
     no_branches: "Aucun site lié à vous dans cette ville."
-    view_details: "Voir les détails"
 
   contacts:
     created: "Le contact a été créé avec succès."

--- a/config/locales/content_resources.pt.yml
+++ b/config/locales/content_resources.pt.yml
@@ -42,7 +42,6 @@ pt:
     branch_studies: "Estudos da sede"
     no_studies: "Sem estudos"
     no_branches: "Não há sedes relacionadas a você nesta cidade."
-    view_details: "Ver detalhes"
 
   contacts:
     created: "O contato foi criado com sucesso."


### PR DESCRIPTION
The city name in the same row already links to the detail page, so the button was redundant. Locale key removed in all four languages. Cities specs pass (4 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh