### PR TITLE
Recruitment progress bar above every study caption

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -97,6 +97,36 @@ $dark: $medici-dark;
   }
 }
 
+// Recruitment progress bar (shown above study titles): pastel tints of the
+// palette's semantic colors so the bar informs without shouting. Fills in
+// seniority order — participants, candidates, prospects — and the white
+// remainder reads as the unmet part of the goal.
+.recruitment-bar {
+  display: flex;
+  height: 10px;
+  margin-bottom: 0.5rem;
+  border: 1px solid rgba($medici-dark, 0.2);
+  border-radius: 50rem;
+  overflow: hidden;
+  background-color: #fff;
+
+  .seg {
+    height: 100%;
+  }
+
+  .seg-participant {
+    background-color: mix($medici-success, #fff, 40%);
+  }
+
+  .seg-candidate {
+    background-color: mix($medici-warning, #fff, 40%);
+  }
+
+  .seg-prospect {
+    background-color: mix($medici-danger, #fff, 40%);
+  }
+}
+
 // Model-specific card styling with colors matching the logo
 // Study card with green styling
 .study-card {

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -12,6 +12,7 @@ class StaticPagesController < ApplicationController
     @categories = Category.in_use
     @selected_category = Category.find_by(id: params[:category])
     @studies = @selected_category ? Study.by_category(@selected_category.id).distinct : Study.all
+    @recruitment = RecruitmentProgress.for(@studies)
   end
 
   # Operation manual: what each role may do, the Colombian regulatory sources the
@@ -57,5 +58,7 @@ class StaticPagesController < ApplicationController
       @branches_by_study = {}
       @city_name = t("static_pages.no_city_selected")
     end
+
+    @recruitment = RecruitmentProgress.for(@studies)
   end
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -8,6 +8,7 @@ class StudiesController < SecureApplicationController
   # GET /studies or /studies.json
   def index
     @studies = Study.all.paginate(page: params[:page], per_page: RECORDS_PER_PAGE)
+    @recruitment = RecruitmentProgress.for(@studies)
   end
 
   # GET /studies/1 or /studies/1.json

--- a/app/models/recruitment_progress.rb
+++ b/app/models/recruitment_progress.rb
@@ -1,0 +1,60 @@
+# Recruitment progress of a study toward its goal (its sample size): how many
+# patients sit in each AASM lifecycle state, expressed as stacked-bar segment
+# widths. Segments fill in seniority order — participants, then candidates,
+# then prospects — and the stacked total is capped at 100% so an over-enrolled
+# study can't overflow the bar; the white remainder is the unmet goal.
+#
+# Use .for(studies) to bulk-load a whole listing with ONE grouped query.
+class RecruitmentProgress
+  STATES = %w[participant candidate prospect].freeze
+
+  attr_reader :goal
+
+  def self.for(studies)
+    studies = Array(studies)
+    grouped = Patient.where(study_id: studies.map(&:id)).group(:study_id, :state).count
+
+    studies.to_h do |study|
+      counts = STATES.index_with { |state| grouped.fetch([ study.id, state ], 0) }
+      [ study.id, new(goal: study.recruitment_goal, counts: counts) ]
+    end
+  end
+
+  def initialize(goal:, counts:)
+    @goal = goal.to_i
+    @counts = counts
+  end
+
+  # Without a positive goal there is no 100% to measure against.
+  def renderable?
+    goal.positive?
+  end
+
+  def count(state)
+    @counts.fetch(state.to_s, 0)
+  end
+
+  def total
+    STATES.sum { |state| count(state) }
+  end
+
+  # Segment width (0.0..100.0) for one state, after the states before it in
+  # STATES order have claimed their share of the bar.
+  def percent(state)
+    segments.fetch(state.to_s, 0.0)
+  end
+
+  private
+
+  def segments
+    @segments ||= begin
+      remaining = 100.0
+      STATES.index_with do |state|
+        raw = renderable? ? (count(state) * 100.0 / goal) : 0.0
+        width = [ raw, remaining ].min.round(1)
+        remaining = (remaining - width).round(1)
+        width
+      end
+    end
+  end
+end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -51,6 +51,13 @@ class Study < ApplicationRecord
   has_and_belongs_to_many :categories
   has_many :trial_center_facilities, through: :trial_center_branches
 
+  # The study's enrollment (patients.study_id) — Patient has owned the inverse
+  # since patients stopped being Users, but this side was never declared.
+  # restrict, not destroy: patients are clinical records; a study with
+  # enrollment must not be deletable in one stroke (the DB's FK already
+  # blocked it — this surfaces the rule at the model layer).
+  has_many :patients, dependent: :restrict_with_error
+
   has_many :articles, dependent: :destroy
   has_many :results, dependent: :destroy
   has_many :trial_cities, dependent: :destroy
@@ -62,6 +69,16 @@ class Study < ApplicationRecord
   enum :study_phase, I: "I", II: "II", III: "III", IV: "IV"
 
   validates :public_title, :scientific_title, :short_title, presence: true
+  validates :sample_size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+
+  # The recruitment goal — how many patients the study needs — IS the study's
+  # sample size; aliased so the recruitment-bar code reads as domain language.
+  alias_attribute :recruitment_goal, :sample_size
+
+  # Prefer RecruitmentProgress.for(studies) when rendering a whole listing.
+  def recruitment_progress
+    RecruitmentProgress.for(self).fetch(id)
+  end
 
   # Home-page category filter: studies attached to the given therapeutic area.
   # A study with no category only appears under "Todos los estudios".

--- a/app/views/static_pages/_medici_showcase.html.erb
+++ b/app/views/static_pages/_medici_showcase.html.erb
@@ -16,7 +16,7 @@
     <div class="row">
       <% @studies.each do |study| %>
         <div class="col-md-3 mb-4">
-          <%= render "static_pages/study_card", study: study %>
+          <%= render "static_pages/study_card", study: study, recruitment: @recruitment[study.id] %>
         </div>
       <% end %>
     </div>

--- a/app/views/static_pages/_study_card.html.erb
+++ b/app/views/static_pages/_study_card.html.erb
@@ -4,6 +4,10 @@
 <% centers = local_assigns[:centers] %>
 <% detail_path = user_signed_in? ? study_path(study) : study_about_path(study) %>
 <div class="card health-card shadow-sm h-100">
+  <%# Recruitment progress sits at the very top of every study caption. %>
+  <div class="px-2 pt-2">
+    <%= render "studies/recruitment_bar", study: study, progress: local_assigns[:recruitment] %>
+  </div>
   <div class="card-header">
     <%= study.public_title %>
   </div>

--- a/app/views/static_pages/search_by_city.html.erb
+++ b/app/views/static_pages/search_by_city.html.erb
@@ -19,7 +19,7 @@
             <div class="row">
               <% @studies.each do |study| %>
                 <div class="col-md-4 mb-4">
-                  <%= render "static_pages/study_card", study: study, centers: @branches_by_study.fetch(study.id, []) %>
+                  <%= render "static_pages/study_card", study: study, centers: @branches_by_study.fetch(study.id, []), recruitment: @recruitment[study.id] %>
                 </div>
               <% end %>
             </div>

--- a/app/views/studies/_recruitment_bar.html.erb
+++ b/app/views/studies/_recruitment_bar.html.erb
@@ -1,0 +1,19 @@
+<%# Stacked recruitment bar: participants → candidates → prospects in pastel
+    tones, white remainder = patients still to recruit. Pass `progress:` from
+    a RecruitmentProgress.for bulk map on listings; falls back to a per-study
+    query otherwise. Hidden entirely when the study has no goal. %>
+<% progress = local_assigns[:progress] || study.recruitment_progress %>
+<% if progress.renderable? %>
+  <div class="recruitment-bar"
+       role="img"
+       aria-label="<%= t("studies.recruitment.aria", total: progress.total, goal: progress.goal) %>"
+       title="<%= t("studies.recruitment.tooltip",
+                    participants: progress.count(:participant),
+                    candidates: progress.count(:candidate),
+                    prospects: progress.count(:prospect),
+                    goal: progress.goal) %>">
+    <div class="seg seg-participant" style="width: <%= progress.percent(:participant) %>%"></div>
+    <div class="seg seg-candidate" style="width: <%= progress.percent(:candidate) %>%"></div>
+    <div class="seg seg-prospect" style="width: <%= progress.percent(:prospect) %>%"></div>
+  </div>
+<% end %>

--- a/app/views/studies/_study.html.erb
+++ b/app/views/studies/_study.html.erb
@@ -1,5 +1,6 @@
 <div class="card study-card">
   <div class="card-header">
+    <%= render "studies/recruitment_bar", study: study %>
     <h1 class="card-title"><strong><%= study.public_title %></strong></h1>
     <h2 class="card-subtitle mb-2 text-body-secondary"><strong><%= study.scientific_title %></strong></h2>
     <h3 class="card-subtitle mb-2 text-body-secondary"><strong><%= Study.human_attribute_name(:short_title) %>: <%= study.short_title %></strong></h3>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -29,7 +29,10 @@
               <tbody>
               <% @studies.order(:study_status).each do |study| %>
                 <tr>
-                  <td><strong><%= link_to study.scientific_title, study %></strong></td>
+                  <td>
+                    <%= render "studies/recruitment_bar", study: study, progress: @recruitment&.fetch(study.id, nil) %>
+                    <strong><%= link_to study.scientific_title, study %></strong>
+                  </td>
                   <td><%= link_to study.sponsor.name, study.sponsor %></td>
                   <td><%= study.trial_center_facilities.count %></td>
                   <td><%= study.cities_names.count %></td>

--- a/config/locales/content_studies.en.yml
+++ b/config/locales/content_studies.en.yml
@@ -1,5 +1,8 @@
 en:
   studies:
+    recruitment:
+      aria: "Recruitment: %{total} of %{goal} patients"
+      tooltip: "Participants: %{participants} · Candidates: %{candidates} · Prospects: %{prospects} · Goal: %{goal}"
     age: "Age"
     interested_subjects: "Subjects interested in the study"
     clinical_trials: "Clinical trials"

--- a/config/locales/content_studies.es.yml
+++ b/config/locales/content_studies.es.yml
@@ -1,5 +1,8 @@
 es:
   studies:
+    recruitment:
+      aria: "Reclutamiento: %{total} de %{goal} pacientes"
+      tooltip: "Participantes: %{participants} · Candidatos: %{candidates} · Prospectos: %{prospects} · Meta: %{goal}"
     age: "Edad"
     interested_subjects: "Sujetos interesados en el estudio"
     clinical_trials: "Ensayos clínicos"

--- a/config/locales/content_studies.fr.yml
+++ b/config/locales/content_studies.fr.yml
@@ -1,5 +1,8 @@
 fr:
   studies:
+    recruitment:
+      aria: "Recrutement : %{total} sur %{goal} patients"
+      tooltip: "Participants : %{participants} · Candidats : %{candidates} · Prospects : %{prospects} · Objectif : %{goal}"
     age: "Âge"
     interested_subjects: "Sujets intéressés par l'étude"
     clinical_trials: "Essais cliniques"

--- a/config/locales/content_studies.pt.yml
+++ b/config/locales/content_studies.pt.yml
@@ -1,5 +1,8 @@
 pt:
   studies:
+    recruitment:
+      aria: "Recrutamento: %{total} de %{goal} pacientes"
+      tooltip: "Participantes: %{participants} · Candidatos: %{candidates} · Prospectos: %{prospects} · Meta: %{goal}"
     age: "Idade"
     interested_subjects: "Sujeitos interessados no estudo"
     clinical_trials: "Ensaios clínicos"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,6 +85,15 @@ CategoriesSeeder.seed!
 #     study.trial_center_branches << TrialCenterBranch.find(TrialCenterBranch.ids.sample((1..3).to_a.sample))
 #     # Every study belongs to 1..3 therapeutic areas (the seeded Category list).
 #     study.categories << Category.order("RANDOM()").limit(rand(1..3))
+#     # Mostly recruiting, a few completed (completed reads as "disabled"), with
+#     # a small recruitment goal so the progress bar shows meaningful fill...
+#     study.update!(study_status: rand < 0.8 ? "recruiting" : "completed",
+#                   sample_size: rand(8..20))
+#     # ...and patients spread across the lifecycle states that fill it:
+#     # participants (green), candidates (yellow), prospects (red).
+#     rand(1..4).times { FactoryBot.create(:patient, :participant, study: study) }
+#     rand(0..4).times { FactoryBot.create(:patient, :candidate, study: study) }
+#     rand(0..5).times { FactoryBot.create(:patient, study: study) }
 #     FactoryBot.create_list(:article, (1..3).to_a.sample, study: study)
 #     FactoryBot.create_list(:contact, (1..2).to_a.sample, study: study)
 #     FactoryBot.create_list(:result, (1..4).to_a.sample, study: study)

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -45,6 +45,16 @@ FactoryBot.define do
     study
     # state defaults to "prospect" (DB default); AASM manages transitions.
 
+    # Lifecycle states (AASM manages transitions in the app; for test/seed
+    # data writing the column directly is fine).
+    trait :candidate do
+      state { "candidate" }
+    end
+
+    trait :participant do
+      state { "participant" }
+    end
+
     # As the public participation form creates them: contact details only, no
     # clinical data, no account.
     trait :lead do

--- a/spec/models/recruitment_progress_spec.rb
+++ b/spec/models/recruitment_progress_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe RecruitmentProgress do
+  def study_with(goal:, participants: 0, candidates: 0, prospects: 0)
+    study = FactoryBot.create(:study, sample_size: goal)
+    participants.times { FactoryBot.create(:patient, :participant, study: study) }
+    candidates.times { FactoryBot.create(:patient, :candidate, study: study) }
+    prospects.times { FactoryBot.create(:patient, study: study) }
+    study
+  end
+
+  it "bulk-loads state counts and segment widths per study" do
+    study = study_with(goal: 10, participants: 3, candidates: 2, prospects: 1)
+
+    progress = described_class.for([ study ]).fetch(study.id)
+
+    expect(progress).to be_renderable
+    expect(progress.count(:participant)).to eq(3)
+    expect(progress.count(:candidate)).to eq(2)
+    expect(progress.count(:prospect)).to eq(1)
+    expect(progress.total).to eq(6)
+    expect(progress.percent(:participant)).to eq(30.0)
+    expect(progress.percent(:candidate)).to eq(20.0)
+    expect(progress.percent(:prospect)).to eq(10.0)
+  end
+
+  it "caps the stacked total at 100% when enrollment exceeds the goal" do
+    study = study_with(goal: 4, participants: 3, candidates: 2, prospects: 2)
+
+    progress = study.recruitment_progress
+
+    expect(progress.percent(:participant)).to eq(75.0)
+    expect(progress.percent(:candidate)).to eq(25.0)
+    # Candidates already reached 100% — prospects get no width at all.
+    expect(progress.percent(:prospect)).to eq(0.0)
+  end
+
+  it "is not renderable without a positive goal" do
+    study = FactoryBot.create(:study, sample_size: nil)
+    FactoryBot.create(:patient, :participant, study: study)
+
+    expect(study.recruitment_progress).not_to be_renderable
+  end
+end

--- a/spec/requests/home_studies_spec.rb
+++ b/spec/requests/home_studies_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe "Home page study showcase", type: :request do
     expect(response.body).to include(new_participation_request_path(study_id: study.id))
   end
 
+  it "shows the recruitment bar above the study caption, and hides it without a goal" do
+    with_goal = FactoryBot.create(:study, sample_size: 10)
+    FactoryBot.create(:patient, :participant, study: with_goal)
+    FactoryBot.create(:study, sample_size: nil, public_title: "Estudio sin meta")
+
+    get root_path
+
+    expect(response.body).to include("recruitment-bar")
+    expect(response.body).to include("seg-participant")
+    # Exactly one bar: the goalless study renders none.
+    expect(response.body.scan("recruitment-bar").size).to eq(1)
+  end
+
   it "renders the mobile-first hero: tagline, stat pills, and the login button at the end" do
     get root_path
 


### PR DESCRIPTION
## What

- **Goal in the model**: `Study#recruitment_goal` aliases `sample_size` (the domain's actual recruitment target — no duplicate column), now validated as a positive integer.
- **`RecruitmentProgress`**: one grouped query per listing; stacked segment widths in seniority order — participants → candidates → prospects — **capped at 100%**, white remainder = unmet goal. No goal → no bar.
- **Rendered at the top of every study caption**: shared public card (home + city search), staff studies index, study page.
- **Pastel palette**: `mix($medici-success/-warning/-danger, #fff, 40%)` — the designated tones, softened; tooltip + aria-label carry the exact counts.
- **Seeds**: sample block puts ~80% of studies in `recruiting`, few `completed`, goals 8–20, and patients spread across the three states (`:candidate`/`:participant` factory traits added).
- Bonus: declares the long-missing `Study has_many :patients` inverse (`restrict_with_error` — patients are clinical records; the DB FK already blocked cascades).

## Verification

- Model specs: counts, widths, 100% capping, goalless hidden. Request spec: bar renders on home, absent for goalless studies.
- Suite: 373 examples, 0 failures; Brakeman + RuboCop clean.
- Headless-Chrome renders shared in session (home cards + staff index, including an over-enrolled capped bar).

No migration; no deploy prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh