### PR TITLE
Read patient data from patients.study_id, not the dead studies_users join

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -13,7 +13,13 @@ class StudiesController < SecureApplicationController
 
   # GET /studies/1 or /studies/1.json
   def show
-    @patients = @study.users.patients
+    # The old @study.users.patients read the dead studies_users join (always
+    # empty since patients stopped being Users). The patient LIST is row-level
+    # data about identifiable people, so it goes through PatientPolicy::Scope:
+    # admins see all of the study's patients, a branch rep only their reach,
+    # roles without Patient access (sponsor reps) an empty list — while the
+    # aggregate counter in the view stays a plain count.
+    @patients = policy_scope(Patient).where(study: @study)
   end
 
   # GET /studies/new

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -98,6 +98,6 @@ class Study < ApplicationRecord
   # Whether ANY patient is enrolled (used by the public info card, which shows a
   # yes/no badge — never a count — to avoid disclosing enrollment numbers).
   def any_patient_enrolled?
-    users.patients.exists?
+    patients.exists?
   end
 end

--- a/app/views/studies/_study.html.erb
+++ b/app/views/studies/_study.html.erb
@@ -7,7 +7,9 @@
   </div>
   <div class="card-body">
     <p class="card-text">
-    <h6><strong><%= t("studies.interested_subjects") %>:</strong> <%= study.users.count %></h6>
+    <%# patients.study_id — the old studies_users HABTM stopped carrying
+        patients when patient accounts were removed (2026-07-15). %>
+    <h6><strong><%= t("studies.interested_subjects") %>:</strong> <%= study.patients.count %></h6>
     <div class="row">
       <div class="col-3">
         <table class="table table-striped">

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -36,7 +36,7 @@
                   <td><%= link_to study.sponsor.name, study.sponsor %></td>
                   <td><%= study.trial_center_facilities.count %></td>
                   <td><%= study.cities_names.count %></td>
-                  <td><span class="badge bg-primary"><%= study.users.count %></span></td>
+                  <td><span class="badge bg-primary"><%= study.patients.count %></span></td>
                   <td>
                     <% status_class = case study.study_status 
                                       when "completed" then "bg-secondary"

--- a/spec/features/study_details_spec.rb
+++ b/spec/features/study_details_spec.rb
@@ -23,7 +23,9 @@ RSpec.feature "Public 'More about this study' card", type: :feature do
 
   scenario "shows a 'yes' badge once a patient is enrolled" do
     study = create(:study)
-    study.users << create(:user, :patient)
+    # A real Patient record (patients.study_id) — enrollment stopped flowing
+    # through the studies_users join when patient accounts were removed.
+    create(:patient, study: study)
     visit study_about_path(study)
     expect(page).to have_css(".badge.bg-success", text: I18n.t("common.yes"))
   end

--- a/spec/requests/studies_show_patients_spec.rb
+++ b/spec/requests/studies_show_patients_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+# The study page's "Sujetos interesados" counter and patient table read
+# patients.study_id — the old studies_users join went permanently empty when
+# patient accounts were removed, so both showed 0/nothing for months.
+RSpec.describe "Study page patient data", type: :request do
+  let(:branch) { FactoryBot.create(:trial_center_branch) }
+  let(:study) { FactoryBot.create(:study).tap { |s| s.trial_center_branches << branch } }
+  let!(:patient) { FactoryBot.create(:patient, :participant, study: study, firstname: "Zoraida") }
+
+  it "shows admins the real pipeline count and the patient list" do
+    sign_in(FactoryBot.create(:user, :admin), scope: :user)
+
+    get study_path(study)
+
+    expect(response).to be_successful
+    expect(response.body).to include("#{I18n.t("studies.interested_subjects")}:</strong> 1")
+    expect(response.body).to include("Zoraida")
+  end
+
+  it "narrows the list to the rep's reach while keeping the aggregate count" do
+    other_branch = FactoryBot.create(:trial_center_branch)
+    rep = FactoryBot.create(:trial_center_branch_rep, trial_center_branch: other_branch)
+    sign_in(FactoryBot.create(:user, userable: rep), scope: :user)
+
+    get study_path(study)
+
+    expect(response).to be_successful
+    # The aggregate stays (it discloses no identity)…
+    expect(response.body).to include("#{I18n.t("studies.interested_subjects")}:</strong> 1")
+    # …but an out-of-reach rep gets no patient rows.
+    expect(response.body).not_to include("Zoraida")
+  end
+end


### PR DESCRIPTION
Found while investigating why study 46 showed "Sujetos interesados: 0" beside a healthy recruitment bar: four spots still read the old `studies_users` HABTM, permanently empty since patients stopped being Users (2026-07-15).

- `_study.html.erb` counter and `studies/index` badge → `study.patients.count`.
- `Study#any_patient_enrolled?` (public yes/no badge) → `patients.exists?`.
- `StudiesController#show` patient list → `policy_scope(Patient).where(study:)` — the list is identity data, so it now goes through `PatientPolicy::Scope` (admins all, branch reps their reach, sponsor reps none). The old code "leaked nothing" only because it was always empty.
- The public-card feature spec enrolled through the same dead join (code and spec shared the bug); now creates a real `Patient`.

New regression specs: admin sees count + list; an out-of-reach rep keeps the aggregate but gets no patient rows. Suite: 375 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh