### PR TITLE
De-flake the consent-gate specs with waiting matchers

### DIFF
--- a/spec/features/participation_requests_spec.rb
+++ b/spec/features/participation_requests_spec.rb
@@ -11,8 +11,16 @@ RSpec.feature "Participation request consent gate", type: :feature, js: true do
 
   before { visit new_participation_request_path(study_id: study.id) }
 
-  def submit_disabled?
-    page.evaluate_script("document.querySelector('input[type=submit]').disabled")
+  # Waiting matchers, not an instant evaluate_script: the button starts
+  # enabled by design (no-JS fail-open; the server is the real gate) and
+  # Stimulus disables it on connect — an instant check can race that boot
+  # and flake (it did, twice, on 2026-07-18).
+  def expect_submit_disabled
+    expect(page).to have_button(I18n.t("participation_requests.submit"), disabled: true)
+  end
+
+  def expect_submit_enabled
+    expect(page).to have_button(I18n.t("participation_requests.submit"), disabled: false)
   end
 
   it "shows the authorization text above the checkbox, not beside it" do
@@ -31,17 +39,17 @@ RSpec.feature "Participation request consent gate", type: :feature, js: true do
   end
 
   it "keeps the submit button disabled until the box is ticked" do
-    expect(submit_disabled?).to be(true)
+    expect_submit_disabled
 
     check "patient_data_processing_authorization"
-    expect(submit_disabled?).to be(false)
+    expect_submit_enabled
   end
 
   it "disables it again if the box is un-ticked" do
     check "patient_data_processing_authorization"
     uncheck "patient_data_processing_authorization"
 
-    expect(submit_disabled?).to be(true)
+    expect_submit_disabled
   end
 
   # The authorization is a legal act, so its state has to be readable at a glance


### PR DESCRIPTION
The consent-gate submit button starts enabled by design (no-JS fail-open; the server-side gate is the real protection) and Stimulus disables it on `connect()` — so the spec's instant `evaluate_script` check could race the controller boot. It flaked twice today (once locally, once in CI — blocking the #59 deploy chain until a rerun).

Fix: Capybara's waiting `have_button(..., disabled: true/false)` matchers, which retry until timeout. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh