### PR TITLE
Color-signaled patient state column; index bar moves to a compact column

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -157,6 +157,26 @@ $dark: $medici-dark;
   scroll-margin-top: 6rem;
 }
 
+// Compact bar column on the studies index: numbers inside, but never wide.
+.recruitment-bar-cell {
+  max-width: 10rem;
+  min-width: 7rem;
+
+  .recruitment-bar {
+    margin-bottom: 0;
+  }
+}
+
+// Patient lifecycle state text, same semantics as the bar's segments. Full
+// semantic tones (not the pastels) so the colored TEXT stays readable.
+.patient-state {
+  font-weight: 600;
+
+  &.patient-state--participant { color: $medici-success; }
+  &.patient-state--candidate { color: darken($medici-warning, 12%); }
+  &.patient-state--prospect { color: $medici-danger; }
+}
+
 .recruitment-legend {
   .dot {
     display: inline-block;

--- a/app/views/studies/_study.html.erb
+++ b/app/views/studies/_study.html.erb
@@ -282,6 +282,7 @@
                 <tr>
                   <th><%= Patient.human_attribute_name(:firstname) %></th>
                   <th><%= t("studies.age") %></th>
+                  <th><%= Patient.human_attribute_name(:state) %></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -289,6 +290,9 @@
                   <tr>
                     <td><%= link_to patient.fullname, patient %></td>
                     <td><%= get_age(patient.dob) if patient.dob.present? %></td>
+                    <%# Same semantics as the bar: participant green, candidate
+                        amber, prospect red. %>
+                    <td><span class="patient-state patient-state--<%= patient.state %>"><%= t("patients.states.#{patient.state}", default: patient.state) %></span></td>
                   </tr>
                 <% end %>
                 </tbody>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -18,6 +18,7 @@
               <thead>
               <tr>
                 <th><%= Study.human_attribute_name(:scientific_title) %></th>
+                <th><%= t("studies.recruitment.title") %></th>
                 <th><%= Study.human_attribute_name(:sponsor) %></th>
                 <th><%= TrialCenterFacility.model_name.human %></th>
                 <th><%= City.model_name.human %></th>
@@ -29,9 +30,13 @@
               <tbody>
               <% @studies.order(:study_status).each do |study| %>
                 <tr>
+                  <td><strong><%= link_to study.scientific_title, study %></strong></td>
                   <td>
-                    <%= render "studies/recruitment_bar", study: study, progress: @recruitment&.fetch(study.id, nil) %>
-                    <strong><%= link_to study.scientific_title, study %></strong>
+                    <%# Compact labeled bar in its own column (numbers inside),
+                        capped by .recruitment-bar-cell so it stays narrow. %>
+                    <div class="recruitment-bar-cell">
+                      <%= render "studies/recruitment_bar", study: study, progress: @recruitment&.fetch(study.id, nil), labeled: true %>
+                    </div>
                   </td>
                   <td><%= link_to study.sponsor.name, study.sponsor %></td>
                   <td><%= study.trial_center_facilities.count %></td>

--- a/spec/requests/studies_show_patients_spec.rb
+++ b/spec/requests/studies_show_patients_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe "Study page patient data", type: :request do
     expect(response.body).to include(I18n.t("studies.interested_subjects"))
     expect(response.body).to include('<span class="badge bg-primary">1</span>')
     expect(response.body).to include("Zoraida")
+    # State column, color-classed with the bar's semantics.
+    expect(response.body).to include('patient-state--participant')
+    expect(response.body).to include(I18n.t("patients.states.participant"))
+  end
+
+  it "shows the compact labeled recruitment bar as a column on the index" do
+    FactoryBot.create(:patient, :candidate, study: study)
+    study.update!(sample_size: 10)
+    sign_in(FactoryBot.create(:user, :admin), scope: :user)
+
+    get studies_path
+
+    expect(response.body).to include("recruitment-bar-cell")
+    expect(response.body).to include("recruitment-bar--labeled")
   end
 
   it "narrows the list to the rep's reach while keeping the aggregate count" do


### PR DESCRIPTION
## What

- **Study page patient list**: new *Estado* column, color-signaled with the recruitment bar's semantics — Participante green, Candidato amber (darkened for text contrast on white), Prospecto red. Uses the existing `patients.states.*` translations.
- **Studies index**: the slim bar above the title becomes its own *Reclutamiento* column with the labeled (numbered) variant, width-capped at 7–10rem so the column stays narrow.

## Verification

- Request specs for the state column classes/labels and the index column markup.
- Suite: 379 examples, 0 failures; Brakeman + RuboCop clean. Screenshots shared in session.

No migration; no deploy prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJMoCANPuX8gKpiav7MDNh